### PR TITLE
Speedier alias model rendering

### DIFF
--- a/source/modelgen.h
+++ b/source/modelgen.h
@@ -121,20 +121,25 @@ typedef struct dnewtriangle_s
 // load this data
 
 typedef struct {
-	byte	v[3];
+	char	v[3];
 	byte	lightnormalindex;
 } trivertx_t;
 
 typedef struct {
-	trivertx_t	bboxmin;	// lightnormal isn't used
-	trivertx_t	bboxmax;	// lightnormal isn't used
+	byte	v[3];
+	byte	lightnormalindex;
+} utrivertx_t;
+
+typedef struct {
+	utrivertx_t	bboxmin;	// lightnormal isn't used
+	utrivertx_t	bboxmax;	// lightnormal isn't used
 	char		name[16];	// frame name from grabbing
 } daliasframe_t;
 
 typedef struct {
 	int			numframes;
-	trivertx_t	bboxmin;	// lightnormal isn't used
-	trivertx_t	bboxmax;	// lightnormal isn't used
+	utrivertx_t	bboxmin;	// lightnormal isn't used
+	utrivertx_t	bboxmax;	// lightnormal isn't used
 } daliasgroup_t;
 
 typedef struct {

--- a/source/psp/video_hardware.h
+++ b/source/psp/video_hardware.h
@@ -230,7 +230,6 @@ extern  cvar_t  r_loadq3models;
 
 extern  cvar_t  r_i_model_animation;
 extern  cvar_t  r_i_model_transform;
-extern  cvar_t  r_ipolations;
 extern  cvar_t  r_asynch;
 
 extern  cvar_t  cl_loadmapcfg;

--- a/source/psp/video_hardware_main.cpp
+++ b/source/psp/video_hardware_main.cpp
@@ -1057,9 +1057,6 @@ void GL_DrawAliasBlendedFrame (aliashdr_t *paliashdr, int pose1, int pose2, floa
 			}
 		}
 
-		// Allocate the vertices.
-		vertex* const out = static_cast<vertex*>(sceGuGetMemory(sizeof(vertex) * count));
-
 		for (int start = vertex_index; vertex_index < (start + count); ++vertex_index)
 		{
 

--- a/source/psp/video_hardware_misc.cpp
+++ b/source/psp/video_hardware_misc.cpp
@@ -316,7 +316,6 @@ void R_Init (void)
     Cvar_RegisterVariable (&r_farclip);
 
 	Cvar_RegisterVariable (&r_asynch);
-    Cvar_RegisterVariable (&r_ipolations);
 	Cvar_RegisterVariable (&gl_keeptjunctions);
     Cvar_RegisterVariable (&r_waterwarp);
 

--- a/source/psp/video_hardware_model.cpp
+++ b/source/psp/video_hardware_model.cpp
@@ -1882,14 +1882,22 @@ void * Mod_LoadAliasFrame (void * pin, maliasframedesc_t *frame)
 	{
 		// these are byte values, so we don't have to worry about
 		// endianness
-		frame->bboxmin.v[i] = pdaliasframe->bboxmin.v[i];
-		frame->bboxmax.v[i] = pdaliasframe->bboxmax.v[i];
+		frame->bboxmin.v[i] = pdaliasframe->bboxmin.v[i] - 128;
+		frame->bboxmax.v[i] = pdaliasframe->bboxmax.v[i] - 128;
 	}
 
 
 	pinframe = (trivertx_t *)(pdaliasframe + 1);
 
 	poseverts[posenum] = pinframe;
+
+	for (i = 0; i < pheader->numverts; i++) {
+		utrivertx_t * unsigned_vert = (utrivertx_t*)&(poseverts[posenum][i]);
+		poseverts[posenum][i].v[0] = unsigned_vert->v[0] - 128;
+		poseverts[posenum][i].v[1] = unsigned_vert->v[1] - 128;
+		poseverts[posenum][i].v[2] = unsigned_vert->v[2] - 128;
+	}
+
 	posenum++;
 
 	pinframe += pheader->numverts;
@@ -1920,8 +1928,8 @@ void *Mod_LoadAliasGroup (void * pin,  maliasframedesc_t *frame)
 	for (i=0 ; i<3 ; i++)
 	{
 		// these are byte values, so we don't have to worry about endianness
-		frame->bboxmin.v[i] = pingroup->bboxmin.v[i];
-		frame->bboxmax.v[i] = pingroup->bboxmax.v[i];
+		frame->bboxmin.v[i] = pingroup->bboxmin.v[i] - 128;
+		frame->bboxmax.v[i] = pingroup->bboxmax.v[i] - 128;
 	}
 
 
@@ -1936,6 +1944,14 @@ void *Mod_LoadAliasGroup (void * pin,  maliasframedesc_t *frame)
 	for (i=0 ; i<numframes ; i++)
 	{
 		poseverts[posenum] = (trivertx_t *)((daliasframe_t *)ptemp + 1);
+
+		for (i = 0; i < pheader->numverts; i++) {
+			utrivertx_t * unsigned_vert = (utrivertx_t*)&(poseverts[posenum][i]);
+			poseverts[posenum][i].v[0] = unsigned_vert->v[0] - 128;
+			poseverts[posenum][i].v[1] = unsigned_vert->v[1] - 128;
+			poseverts[posenum][i].v[2] = unsigned_vert->v[2] - 128;
+		}
+
 		posenum++;
 
 		ptemp = (trivertx_t *)((daliasframe_t *)ptemp + 1) + pheader->numverts;
@@ -2450,8 +2466,8 @@ void Mod_LoadAliasModel (model_t *mod, void *buffer)
 	for (i=0 ; i<3 ; i++)
 	{
 		pheader->scale[i] = LittleFloat (pinmodel->scale[i]);
-		pheader->scale_origin[i] = LittleFloat (pinmodel->scale_origin[i]);
-		pheader->eyeposition[i] = LittleFloat (pinmodel->eyeposition[i]);
+		pheader->scale_origin[i] = LittleFloat (pinmodel->scale_origin[i]) + pheader->scale[i] * 128;
+		pheader->eyeposition[i] = LittleFloat (pinmodel->eyeposition[i]) + pheader->scale[i] * 128;
 	}
 //
 // load the skins


### PR DESCRIPTION
Ports changes from interstices compressed verts, removes per vertex shading, and allocates models verts all at once. Also cleans up unused code from video_hardware_main a bit.