### PR TITLE
Port broad phase clipping checks from interstice

### DIFF
--- a/source/psp/video_hardware.h
+++ b/source/psp/video_hardware.h
@@ -332,6 +332,8 @@ void EmitBothSkyLayers (msurface_t *fa);
 void EmitUnderWaterPolys (void);
 void EmitDetailPolys (void);
 void R_DrawSkyChain (msurface_t *s);
+int R_FrustumCheckBox (vec3_t mins, vec3_t maxs);
+int R_FrustumCheckSphere (vec3_t centre, float radius);
 int R_CullBox (vec3_t emins, vec3_t emaxs);
 qboolean R_CullSphere (vec3_t centre, float radius);
 void R_MarkLights (dlight_t *light, int bit, mnode_t *node);

--- a/source/psp/video_hardware_main.cpp
+++ b/source/psp/video_hardware_main.cpp
@@ -311,6 +311,50 @@ void R_RotateForViewEntity (entity_t *ent)
 
 /*
 =================
+R_FrustumCheckBox
+Returns 0 if box completely inside frustum
+Returns +N with intersected planes count as N
+Returns -1 when completely outside frustum
+=================
+*/
+int R_FrustumCheckBox (vec3_t mins, vec3_t maxs)
+{
+	int i, res;
+	int intersections = 0;
+	for (i=0 ; i<4 ; i++)
+	{
+		res = BoxOnPlaneSide (mins, maxs, &frustum[i]);
+		if (res == 2) return -1; 
+		if (res == 3) ++intersections;
+	}
+
+	return intersections;
+}
+
+/*
+=================
+R_FrustumCheckSphere
+=================
+*/
+int R_FrustumCheckSphere (vec3_t centre, float radius)
+{
+	int		i, res;
+	mplane_t	*p;
+	int intersections = 0;
+
+	for (i=0, p=frustum ; i<4 ; i++, p++)
+	{
+		res = PlaneDiff(centre, p);
+		if (res <= -radius) return -1;
+		if (res < radius) ++intersections;
+	}
+
+	return intersections;
+}
+
+
+/*
+=================
 R_CullBox
 Returns true if the box is completely outside the frustom
 =================

--- a/source/psp/video_hardware_model.h
+++ b/source/psp/video_hardware_model.h
@@ -120,6 +120,8 @@ typedef struct texture_s
 #define TEXFLAG_REFLECT		512
 #define TEXFLAG_NORMAL		1024
 
+#define SURF_NEEDSCLIPPING	2048 // see texflags below
+
 // !!! if this is changed, it must be changed in asm_draw.h too !!!
 typedef struct
 {

--- a/source/psp/video_hardware_warp.cpp
+++ b/source/psp/video_hardware_warp.cpp
@@ -398,6 +398,15 @@ void EmitWaterPolys (msurface_t *fa)
 			++dst;
 		}
 
+		if (!(fa->flags & SURF_NEEDSCLIPPING))
+		{
+			sceGuDrawArray(
+				GU_TRIANGLE_FAN,
+				GU_TEXTURE_32BITF | GU_VERTEX_32BITF,
+				unclipped_vertex_count, 0, unclipped_vertices);
+			return;
+		}
+
 		// Do these vertices need clipped?
 		if (clipping::is_clipping_required(unclipped_vertices, unclipped_vertex_count))
 		{


### PR DESCRIPTION
needed to add separate frustum check sphere and box because of rotating bmodels, otherwise near identical with interstice