### PR TITLE
Render static brush models with world

### DIFF
--- a/source/cl_main.c
+++ b/source/cl_main.c
@@ -73,6 +73,8 @@ modelindex_t		cl_modelindex[NUM_MODELINDEX];
 
 int				cl_numvisedicts;
 entity_t		*cl_visedicts[MAX_VISEDICTS];
+int				cl_numstaticbrushmodels;
+entity_t		*cl_staticbrushmodels[MAX_VISEDICTS];
 
 void CL_ClearTEnts (void);
 
@@ -547,7 +549,7 @@ void CL_RelinkEntities (void)
 
 
 	cl_numvisedicts = 0;
-
+	cl_numstaticbrushmodels = 0;
 //
 // interpolate player info
 //
@@ -589,6 +591,23 @@ void CL_RelinkEntities (void)
             ent->translate_start_time = 0;
             ent->rotate_start_time    = 0;
 			continue;
+		}
+
+		// shpuld: if brush model is at 0 with no angle changes, we can draw it with world
+		if (ent->model->type == mod_brush && cl_numstaticbrushmodels < MAX_VISEDICTS)
+		{
+			if (ent->msg_origins[0][0] == 0 &&
+				ent->msg_origins[0][1] == 0 &&
+				ent->msg_origins[0][2] == 0 &&
+				ent->msg_angles[0][0] == 0 &&
+				ent->msg_angles[0][1] == 0 &&
+				ent->msg_angles[0][2] == 0 &&
+				(ent->rendermode == 0 || ent->rendermode == TEX_SOLID || ent->rendermode == TEX_TEXTURE))
+			{
+				cl_staticbrushmodels[cl_numstaticbrushmodels] = ent;
+				cl_numstaticbrushmodels++;
+				continue;
+			}
 		}
 
 		VectorCopy (ent->origin, oldorg);

--- a/source/client.h
+++ b/source/client.h
@@ -332,6 +332,8 @@ void CL_NextDemo (void);
 #define			MAX_VISEDICTS	256
 extern	int				cl_numvisedicts;
 extern	entity_t		*cl_visedicts[MAX_VISEDICTS];
+extern	int				cl_numstaticbrushmodels;
+extern	entity_t		*cl_staticbrushmodels[MAX_VISEDICTS];
 
 
 

--- a/source/psp/video_hardware_main.cpp
+++ b/source/psp/video_hardware_main.cpp
@@ -1063,8 +1063,7 @@ void GL_DrawAliasFrame (aliashdr_t *paliashdr, int posenum)
 	struct vertex
 	{
 		int uvs;
-		char x, y, z;
-		char _padding;
+		int xyz;
 	};
 
 	sceGuColor(GU_COLOR(lightcolor[0], lightcolor[1], lightcolor[2], 1.0f));
@@ -1116,17 +1115,11 @@ void GL_DrawAliasFrame (aliashdr_t *paliashdr, int posenum)
 				//prim = GU_TRIANGLES; //used for blubs' alternate BuildTris with one continual triangle list
 			}
 			//================================================================== fps: 50 ===============================================
-			for (int start = vertex_index; vertex_index < (start + count); ++vertex_index)
+			for (int start = vertex_index; vertex_index < (start + count); ++vertex_index, ++order, ++verts)
 			{
 				// texture coordinates come from the draw list
 				out[vertex_index].uvs = order[0];
-				order += 1;
-
-				out[vertex_index].x = verts->v[0];
-				out[vertex_index].y = verts->v[1];
-				out[vertex_index].z = verts->v[2];
-
-				++verts;
+				out[vertex_index].xyz = ((int*)verts->v)[0]; // cast to int because trivertx is is 4 bytes
 			}
 			sceGuDrawArray(prim, GU_TEXTURE_16BIT | GU_VERTEX_8BIT, count, 0, &out[vertex_index - count]);
 			
@@ -1204,26 +1197,17 @@ void GL_DrawAliasBlendedFrame (aliashdr_t *paliashdr, int pose1, int pose2, floa
 			//prim = GU_TRIANGLES; //used for blubs' alternate BuildTris with one continual triangle list
 		}
 
-		for (int start = vertex_index; vertex_index < (start + count); ++vertex_index)
+		for (int start = vertex_index; vertex_index < (start + count); ++vertex_index, ++order, ++verts1, ++verts2)
 		{
-
 			// texture coordinates come from the draw list
 			out[vertex_index].uvs = order[0];
-			order += 1;
 
 			VectorSubtract(verts2->v, verts1->v, d);
 
 			// blend the vertex positions from each frame together
-			point[0] = verts1->v[0] + (blend * d[0]);
-			point[1] = verts1->v[1] + (blend * d[1]);
-			point[2] = verts1->v[2] + (blend * d[2]);
-
-			out[vertex_index].x = point[0];
-			out[vertex_index].y = point[1];
-			out[vertex_index].z = point[2];
-
-			++verts1;
-			++verts2;
+			out[vertex_index].x = verts1->v[0] + (blend * d[0]);
+			out[vertex_index].y = verts1->v[1] + (blend * d[1]);
+			out[vertex_index].z = verts1->v[2] + (blend * d[2]);
 		}
 		sceGuDrawArray(prim, GU_TEXTURE_16BIT | GU_VERTEX_8BIT, count, 0, &out[vertex_index - count]);
 	}


### PR DESCRIPTION
Detects brush models that are at 0 0 0 and with angles 0 0 0, which can then be drawn together with world. Exceptions apply to brushes using HL render modes. I noticed that rendermodes TEXTURE and SOLID work the same and don't work as specified, so I wrote that down and made them both work explicitly like fences with lightmaps (which means improved visuals). These changes improve performance by a few frames in the tricky spot. I went through custom maps and didn't see negative side effects to fence textures being lightmapped. In addition, lightmapped fences no longer darken or brighten the colors behind the transparent parts.