### PR TITLE
Fix doors/obstacles losing their lightmaps when they're moving

### DIFF
--- a/source/psp/video_hardware_surface.cpp
+++ b/source/psp/video_hardware_surface.cpp
@@ -1320,7 +1320,10 @@ void R_DrawBrushModel (entity_t *e)
 
 
 	if(dlight)
+	{
+		sceGuDisable(GU_ALPHA_TEST);
 		R_BlendLightmaps ();
+	}
 
 	if (ISADDITIVE(e))
 	{


### PR DESCRIPTION
regression from my previous work