### PR TITLE
Even faster pathfinding

### DIFF
--- a/source/mathlib.h
+++ b/source/mathlib.h
@@ -89,6 +89,8 @@ extern	int nanmask;
 
 #define VectorNormalizeFast( v ){float	ilength = (float)rsqrt(DotProduct(v,v));v[0] *= ilength;v[1] *= ilength;v[2] *= ilength; }
 
+#define VectorDistanceSquared(a,b)((a[0]-b[0])*(a[0]-b[0])+(a[1]-b[1])*(a[1]-b[1])+(a[2]-b[2])*(a[2]-b[2]))
+
 typedef float matrix3x4[3][4];
 typedef float matrix3x3[3][3];
 

--- a/source/pr_cmds.c
+++ b/source/pr_cmds.c
@@ -1865,7 +1865,7 @@ Do_Pathfind
 float Do_Pathfind (entity zombie, entity target)
 =================
 */
-#define MEASURE_PF_PERF
+// #define MEASURE_PF_PERF
 float max_waypoint_distance = 750;
 short closest_waypoints[MAX_EDICTS]; 
 

--- a/source/pr_edict.c
+++ b/source/pr_edict.c
@@ -156,6 +156,9 @@ FIXME: walk all entities and NULL out references to this entity
 */
 void ED_Free (edict_t *ed)
 {
+	// pathfind optimization:
+	closest_waypoints[NUM_FOR_EDICT(ed)] = -1;
+
 	SV_UnlinkEdict (ed);		// unlink from world bsp
 
 	ed->free = true;

--- a/source/quakedef.h
+++ b/source/quakedef.h
@@ -37,6 +37,7 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #include <stdio.h>
 #include <stdlib.h>
 #include <setjmp.h>
+#include <ctype.h>
 //#include <assert.h> // For QMB assert
 
 
@@ -353,6 +354,7 @@ typedef struct
 } waypoint_ai;
 
 extern waypoint_ai waypoints[MAX_WAYPOINTS];
+extern short closest_waypoints[MAX_EDICTS];
 
 
 // thread structs

--- a/source/sv_main.c
+++ b/source/sv_main.c
@@ -1484,7 +1484,7 @@ void Load_Waypoint ()
 				}
 			}
 		}
-		Con_Printf("Waypoint (%i)\n target: %i (%i, %f),\n target2: %i (%i, %f),\n target3: %i (%i, %f),\n target4: %i (%i, %f),\n target5: %i (%i, %f),\n target6: %i (%i, %f),\n target7: %i (%i, %f),\n target8: %i (%i, %f)\n",
+		Con_DPrintf("Waypoint (%i)\n target: %i (%i, %f),\n target2: %i (%i, %f),\n target3: %i (%i, %f),\n target4: %i (%i, %f),\n target5: %i (%i, %f),\n target6: %i (%i, %f),\n target7: %i (%i, %f),\n target8: %i (%i, %f)\n",
 		waypoints[i].id,
 		waypoints[i].target[0],
 		waypoints[i].target_id[0],


### PR DESCRIPTION
This gives zombies and players (and other entities) a stored value for last waypoint that is then used to try find a good comparison for closest visible checkpoint to begin with. Saves *a ton* of SV_Move calls which were causing the huge hitches previously.

Also fixes waypoint id 0 to be valid, previously the engine made sure it can't be used but not very clearly...