### PR TITLE
Decrease Loading Time

### DIFF
--- a/source/pr_edict.c
+++ b/source/pr_edict.c
@@ -903,15 +903,7 @@ if (!strcmp(com_token, "light"))
 		key = ED_FindField (keyname);
 		if (!key)
 		{
-			if (strcmp (keyname, "compiler") &&
-				strcmp (keyname, "r_skycolor") &&
-				strcmp (keyname, "sequence") &&
-				strcmp (keyname, "message2") && //dirty hack to keep the console clean. Dem lazy mappers
-				strcmp (keyname, "mangle") &&
-				strcmp (keyname, "Maxrange") &&
-				strcmp (keyname, "light_lev") &&
-				strcmp (keyname, "fog"))
-				Con_Printf ("'%s' is not a field\n", keyname);
+			// cypress -- removed useless conprints
 			continue;
 		}
 
@@ -1062,8 +1054,8 @@ void PR_LoadProgs (void)
 
 	if (progs->version != PROG_VERSION)
 		Sys_Error ("progs.dat has wrong version number (%i should be %i)", progs->version, PROG_VERSION);
-	if (progs->crc != PROGHEADER_CRC)
-		Con_Printf ("WARNING!!! progs.dat system vars have been modified, progdefs.h is out of date. Current one is %i\n", progs->crc);
+	// if (progs->crc != PROGHEADER_CRC)
+	// 	Con_Printf ("WARNING!!! progs.dat system vars have been modified, progdefs.h is out of date. Current one is %i\n", progs->crc);
 
 	pr_functions = (dfunction_t *)((byte *)progs + progs->ofs_functions);
 	pr_strings = (char *)progs + progs->ofs_strings;

--- a/source/psp/video_hardware.h
+++ b/source/psp/video_hardware.h
@@ -35,7 +35,7 @@ int GL_LoadTexture8to4(const char *identifier, unsigned int width, unsigned int 
 int GL_LoadTextureLM (const char *identifier, int width, int height, const byte *data, int bpp, int filter, qboolean update, int forcopy);
 int GL_LoadImages (const char *identifier, int width, int height, const byte *data, qboolean stretch_to_power_of_two, int filter, int mipmap_level, int bpp);
 int GL_LoadTexturePixels (byte *data, char *identifier, int width, int height, int mode);
-int loadtextureimage (char* filename, int matchwidth, int matchheight, qboolean complain, int filter);
+int loadtextureimage (char* filename, int matchwidth, int matchheight, qboolean complain, int filter, int type);
 int GL_LoadPaletteTexture (const char *identifier, int width, int height, const byte *data, byte *palette, int paltype, qboolean stretch_to_power_of_two, int filter, int mipmap_level);
 
 //Crow_bar

--- a/source/psp/video_hardware_QMB.cpp
+++ b/source/psp/video_hardware_QMB.cpp
@@ -444,7 +444,7 @@ void QMB_InitParticles (void)
 
 	loading_num_step = loading_num_step + 24;
 	
-	if (!(particleimage = loadtextureimage("textures/particles/particlefont", 0, 0, qfalse, GU_LINEAR)))
+	if (!(particleimage = loadtextureimage("textures/particles/particlefont", 0, 0, qfalse, GU_LINEAR, 0)))
 	{
 		//Clear_LoadingFill ();
 		return;
@@ -471,7 +471,7 @@ void QMB_InitParticles (void)
 	SCR_UpdateScreen ();
 
 	// load the rest of the images
-	if(!(particleimage = loadtextureimage("textures/particles/q3particlefont", 0, 0, qfalse, GU_LINEAR)))
+	if(!(particleimage = loadtextureimage("textures/particles/q3particlefont", 0, 0, qfalse, GU_LINEAR, 0)))
 	{
 		//Clear_LoadingFill ();
 		return;
@@ -496,7 +496,7 @@ void QMB_InitParticles (void)
 	
 	max_s = max_t = 128.0;
 
-	if (!(particleimage = loadtextureimage("textures/particles/flame", 0, 0, qfalse, GU_LINEAR)))
+	if (!(particleimage = loadtextureimage("textures/particles/flame", 0, 0, qfalse, GU_LINEAR, 0)))
 	{
 		//Clear_LoadingFill ();
 		return;
@@ -511,7 +511,7 @@ void QMB_InitParticles (void)
     loading_cur_step++;
 	SCR_UpdateScreen ();
 
-	if (!(particleimage = loadtextureimage("textures/particles/inferno", 0, 0, qfalse, GU_LINEAR)))
+	if (!(particleimage = loadtextureimage("textures/particles/inferno", 0, 0, qfalse, GU_LINEAR, 0)))
 	{
 		//Clear_LoadingFill ();
 		return;
@@ -522,7 +522,7 @@ void QMB_InitParticles (void)
 	loading_cur_step++;
 	SCR_UpdateScreen ();
 
-	if (!(particleimage = loadtextureimage("textures/particles/zing1", 0, 0, qfalse, GU_LINEAR)))
+	if (!(particleimage = loadtextureimage("textures/particles/zing1", 0, 0, qfalse, GU_LINEAR, 0)))
 	{
         //Clear_LoadingFill ();
 		return;
@@ -535,7 +535,7 @@ void QMB_InitParticles (void)
 	SCR_UpdateScreen ();
 	max_s = max_t = 128.0;
 	
-	if (!(particleimage = loadtextureimage("textures/mzfl/mzfl0", 0, 0, qfalse, GU_LINEAR)))
+	if (!(particleimage = loadtextureimage("textures/mzfl/mzfl0", 0, 0, qfalse, GU_LINEAR, 0)))
 	{
 		//Clear_LoadingFill ();
 		return;
@@ -550,7 +550,7 @@ void QMB_InitParticles (void)
 
 #ifdef SLIM
 
-	if (!(particleimage = loadtextureimage("textures/mzfl/mzfl1", 0, 0, qfalse, GU_LINEAR)))
+	if (!(particleimage = loadtextureimage("textures/mzfl/mzfl1", 0, 0, qfalse, GU_LINEAR, 0)))
 	{
 		//Clear_LoadingFill ();
 		return;
@@ -560,7 +560,7 @@ void QMB_InitParticles (void)
 
     loading_cur_step++;	
 	SCR_UpdateScreen ();
-	if (!(particleimage = loadtextureimage("textures/mzfl/mzfl2", 0, 0, qfalse, GU_LINEAR)))
+	if (!(particleimage = loadtextureimage("textures/mzfl/mzfl2", 0, 0, qfalse, GU_LINEAR, 0)))
 	{
         //Clear_LoadingFill ();
 		return;
@@ -574,7 +574,7 @@ void QMB_InitParticles (void)
 #endif // SLIM
 	
 	max_s = max_t = 64.0;
-	if (!(particleimage = loadtextureimage("textures/particles/bloodcloud", 0, 0, qfalse, GU_LINEAR)))
+	if (!(particleimage = loadtextureimage("textures/particles/bloodcloud", 0, 0, qfalse, GU_LINEAR, 0)))
 	{
         //Clear_LoadingFill ();
 		return;

--- a/source/psp/video_hardware_decals_QMB.cpp
+++ b/source/psp/video_hardware_decals_QMB.cpp
@@ -115,23 +115,7 @@ void R_InitDecals (void)
 
 	if (!qmb_initialized)
 		return;
-/*
- decal_blood1  = loadtextureimage("textures/decals/blood_splat01",   0, 0, qfalse, GU_LINEAR);
- decal_blood2  = loadtextureimage("textures/decals/blood_splat02",   0, 0, qfalse, GU_LINEAR);
- decal_blood3  = loadtextureimage("textures/decals/blood_splat03",   0, 0, qfalse, GU_LINEAR);
- decal_q3blood = loadtextureimage("textures/decals/blood_stain",     0, 0, qfalse, GU_LINEAR);
- decal_burn    = loadtextureimage("textures/decals/explo_burn01",    0, 0, qfalse, GU_LINEAR);
- decal_mark    = loadtextureimage("textures/decals/particle_burn01", 0, 0, qfalse, GU_LINEAR);
- decal_glow    = loadtextureimage("textures/decals/glow2",           0, 0, qfalse, GU_LINEAR);
 
-	decal_blood1 = GL_LoadTextureImage ("textures/decals/blood_splat01", "decals:blood_splat01", 128, 128, TEX_ALPHA | TEX_COMPLAIN);
-	decal_blood2 = GL_LoadTextureImage ("textures/decals/blood_splat02", "decals:blood_splat02", 128, 128, TEX_ALPHA | TEX_COMPLAIN);
-	decal_blood3 = GL_LoadTextureImage ("textures/decals/blood_splat03", "decals:blood_splat03", 128, 128, TEX_ALPHA | TEX_COMPLAIN);
-	decal_q3blood = GL_LoadTextureImage ("textures/decals/blood_stain", "decals:blood_stain", 64, 64, TEX_ALPHA | TEX_COMPLAIN);
-	decal_burn = GL_LoadTextureImage ("textures/decals/explo_burn01", "decals:explo_burn01", 128, 128, TEX_ALPHA | TEX_COMPLAIN);
-	decal_mark = GL_LoadTextureImage ("textures/decals/particle_burn01", "decals:particle_burn01", 64, 64, TEX_ALPHA | TEX_COMPLAIN);
-	decal_glow = GL_LoadTextureImage ("textures/decals/glow2", "decals:glow2", 64, 64, TEX_ALPHA | TEX_COMPLAIN);
-*/
 	if ((i = COM_CheckParm("-decals")) && i + 1 < com_argc)
 	{
 		r_numdecals = Q_atoi(com_argv[i+1]);
@@ -389,7 +373,7 @@ void R_SpawnDecalBSP (vec3_t org, char *texname, int size)
 	if (!qmb_initialized)
 		return;
 
-	int tex = loadtextureimage(va("decals/%s",texname),   0, 0, qfalse, GU_LINEAR);
+	int tex = loadtextureimage(va("decals/%s",texname),   0, 0, qfalse, GU_LINEAR, 0);
 	if(!tex) //find in decals.wad
 	{
 		if(wadreload)

--- a/source/psp/video_hardware_draw.cpp
+++ b/source/psp/video_hardware_draw.cpp
@@ -95,7 +95,7 @@ typedef struct
 	texel*	vram;
 } gltexture_t;
 
-int loadtextureimage (char* filename, int matchwidth, int matchheight, qboolean complain, int filter);
+int loadtextureimage (char* filename, int matchwidth, int matchheight, qboolean complain, int filter, int type);
 void VID_SetPalette4(unsigned char* clut4pal);
 
 #define	MAX_GLTEXTURES	1024
@@ -363,7 +363,7 @@ qpic_t	*Draw_CachePic (char *path)
 // load the pic from disk
 //
 
-	int index = loadtextureimage (str, 0, 0, qfalse, GU_LINEAR);
+	int index = loadtextureimage (str, 0, 0, qfalse, GU_LINEAR, 0);
 	if(index)
 	{
 		pic->pic.width  = gltextures[index].original_width;
@@ -425,7 +425,7 @@ qpic_t	*Draw_CacheImg (char *path)
 // load the pic from disk
 //
 
-	int index = loadtextureimage (path, 0, 0, qfalse, GU_LINEAR);
+	int index = loadtextureimage (path, 0, 0, qfalse, GU_LINEAR, 0);
 	if(index != -1)
 	{
 		pic->pic.width  = gltextures[index].original_width;
@@ -531,11 +531,11 @@ void Draw_Init (void)
 	R_CreateDlightImage();
 
 	// now turn them into textures
-	char_texture = loadtextureimage ("gfx/charset", 0, 0, qfalse, GU_NEAREST);
+	char_texture = loadtextureimage ("gfx/charset", 0, 0, qfalse, GU_NEAREST, 0);
 	if (char_texture == 0)// did not find a matching TGA...
 		Sys_Error ("Could not load charset, make sure you have every folder and file installed properly\nDouble check that all of your files are in their correct places\nAnd that you have installed the game properly.\nRefer to the readme.txt file for help\n");
 
-	detail_texture = loadtextureimage ("gfx/detail", 0, 0, qfalse, GU_LINEAR);
+	detail_texture = loadtextureimage ("gfx/detail", 0, 0, qfalse, GU_LINEAR, 0);
 
 	if (detail_texture == 0)// did not find a matching TGA...
 	{
@@ -551,22 +551,22 @@ void Draw_Init (void)
 
 	sniper_scope = Draw_CachePic ("gfx/hud/scope_256");
 	
-	zombie_skins[0][0] = loadtextureimage ("models/ai/zfull.mdl_0", 0, 0, qtrue, GU_LINEAR);
+	zombie_skins[0][0] = loadtextureimage ("models/ai/zfull.mdl_0", 0, 0, qtrue, GU_LINEAR, 1);
 
 
 	// PSP PHAT: Only have 1 Zombie skin.. this saves 192kB of VRAM, well worth it.
 
 #ifdef SLIM
 
-	zombie_skins[0][1] = loadtextureimage ("models/ai/zfull.mdl_1", 0, 0, qtrue, GU_LINEAR);
-	zombie_skins[1][0] = loadtextureimage ("models/ai/zfull.mdl_2", 0, 0, qtrue, GU_LINEAR);
-	zombie_skins[1][1] = loadtextureimage ("models/ai/zfull.mdl_3", 0, 0, qtrue, GU_LINEAR);
+	zombie_skins[0][1] = loadtextureimage ("models/ai/zfull.mdl_1", 0, 0, qtrue, GU_LINEAR, 1);
+	zombie_skins[1][0] = loadtextureimage ("models/ai/zfull.mdl_2", 0, 0, qtrue, GU_LINEAR, 1);
+	zombie_skins[1][1] = loadtextureimage ("models/ai/zfull.mdl_3", 0, 0, qtrue, GU_LINEAR, 1);
 
 #else
 
-	zombie_skins[0][1] = loadtextureimage ("models/ai/zfull.mdl_0", 0, 0, qtrue, GU_LINEAR);
-	zombie_skins[1][0] = loadtextureimage ("models/ai/zfull.mdl_0", 0, 0, qtrue, GU_LINEAR);
-	zombie_skins[1][1] = loadtextureimage ("models/ai/zfull.mdl_0", 0, 0, qtrue, GU_LINEAR);
+	zombie_skins[0][1] = loadtextureimage ("models/ai/zfull.mdl_0", 0, 0, qtrue, GU_LINEAR, 1);
+	zombie_skins[1][0] = loadtextureimage ("models/ai/zfull.mdl_0", 0, 0, qtrue, GU_LINEAR, 1);
+	zombie_skins[1][1] = loadtextureimage ("models/ai/zfull.mdl_0", 0, 0, qtrue, GU_LINEAR, 1);
 
 #endif // SLIM
 	

--- a/source/psp/video_hardware_draw.cpp
+++ b/source/psp/video_hardware_draw.cpp
@@ -1006,7 +1006,7 @@ void Draw_LoadingFill(void)
 	switch(loading_step) {
 		case 1: text = "Loading Models.."; break;
 		case 2: text = "Loading World.."; break;
-		case 3: text = "Running Test Frame.."; break;
+		case 3: text = "Running Spawn Functions.."; break;
 		case 4: text = "Loading Sounds.."; break;
 		default: text = "Initializing.."; break;
 	}

--- a/source/psp/video_hardware_images.cpp
+++ b/source/psp/video_hardware_images.cpp
@@ -990,7 +990,7 @@ loadimagepixels
 =============
 */
 										// HACK HACK HACK
-byte* loadimagepixels (char* filename, qboolean complain, int matchwidth, int matchheight)
+byte* loadimagepixels (char* filename, qboolean complain, int matchwidth, int matchheight, int type)
 {
 	FILE	*f;
 	char	basename[128], name[128];
@@ -1011,21 +1011,20 @@ byte* loadimagepixels (char* filename, qboolean complain, int matchwidth, int ma
 	}
 
 	com_netpath[0] = 0;
-/*
-    sprintf (name, "%s.wal", basename);
-	if (data = LoadWAL(name))
-		return data;
-*/
+
+	sprintf (name, "%s.pcx", basename);
+	FS_FOpenFile (name, &f);
+	if (f)
+		return LoadPCX (f, matchwidth, matchheight);
+
+	// models only support loading PCX textures
+	if (type == 1)
+		return NULL;
 
 	sprintf (name, "%s.tga", basename);
 	FS_FOpenFile (name, &f);
 	if (f)
 		return LoadTGA (f, matchwidth, matchheight);
-		
-	sprintf (name, "%s.pcx", basename);
-	FS_FOpenFile (name, &f);
-	if (f)
-		return LoadPCX (f, matchwidth, matchheight);
 	
 	sprintf (name, "%s.jpg", basename);
 	FS_FOpenFile (name, &f);
@@ -1038,13 +1037,6 @@ byte* loadimagepixels (char* filename, qboolean complain, int matchwidth, int ma
 	if (f)
 		return LoadPNG (f, matchwidth, matchheight);
 	
-	sprintf (name, "%s.bmp", basename);
-	FS_FOpenFile (name, &f);
-	if (f)
-		return LoadBMP (f, matchwidth, matchheight);
-	//if (complain)
-	//	Con_Printf ("Couldn't load %s .tga .jpg .bmp .png \n", filename);
-	
 	return NULL;
 }
 
@@ -1054,13 +1046,13 @@ loadtextureimage
 =============
 */
 
-int loadtextureimage (char* filename, int matchwidth, int matchheight, qboolean complain, int filter)
+int loadtextureimage (char* filename, int matchwidth, int matchheight, qboolean complain, int filter, int type)
 {
 	int texture_index;
 	byte *data;
 
 	int hunk_start = Hunk_LowMark();
-	data = loadimagepixels (filename, complain, matchwidth, matchheight);
+	data = loadimagepixels (filename, complain, matchwidth, matchheight, type);
 	int hunk_stop = Hunk_LowMark();
 
 	if(!data)

--- a/source/psp/video_hardware_misc.cpp
+++ b/source/psp/video_hardware_misc.cpp
@@ -44,13 +44,13 @@ R_InitOtherTextures
 void	R_InitOtherTextures (void)
 {
 	//static decals
-	decal_blood1  = loadtextureimage ("textures/decals/blood_splat01", 0, 0, qfalse, GU_LINEAR);
-	decal_blood2  = loadtextureimage ("textures/decals/blood_splat02", 0, 0, qfalse, GU_LINEAR);
-	decal_blood3  = loadtextureimage ("textures/decals/blood_splat03", 0, 0, qfalse, GU_LINEAR);
-    decal_q3blood = loadtextureimage ("textures/decals/blood_stain", 0, 0, qfalse, GU_LINEAR);
-	decal_burn	  = loadtextureimage ("textures/decals/explo_burn01", 0, 0, qfalse, GU_LINEAR);
-	decal_mark	  = loadtextureimage ("textures/decals/particle_burn01", 0, 0, qfalse, GU_LINEAR);
-	decal_glow	  = loadtextureimage ("textures/decals/glow2", 0, 0, qfalse, GU_LINEAR);
+	decal_blood1  = loadtextureimage ("textures/decals/blood_splat01", 0, 0, qfalse, GU_LINEAR, 0);
+	decal_blood2  = loadtextureimage ("textures/decals/blood_splat02", 0, 0, qfalse, GU_LINEAR, 0);
+	decal_blood3  = loadtextureimage ("textures/decals/blood_splat03", 0, 0, qfalse, GU_LINEAR, 0);
+    decal_q3blood = loadtextureimage ("textures/decals/blood_stain", 0, 0, qfalse, GU_LINEAR, 0);
+	decal_burn	  = loadtextureimage ("textures/decals/explo_burn01", 0, 0, qfalse, GU_LINEAR, 0);
+	decal_mark	  = loadtextureimage ("textures/decals/particle_burn01", 0, 0, qfalse, GU_LINEAR, 0);
+	decal_glow	  = loadtextureimage ("textures/decals/glow2", 0, 0, qfalse, GU_LINEAR, 0);
 }
 
 /*

--- a/source/psp/video_hardware_model.cpp
+++ b/source/psp/video_hardware_model.cpp
@@ -573,7 +573,7 @@ void Mod_LoadTextures (lump_t *l)
 			}
 			
 			if (!f) {
-				Con_Printf("Loading texture %s as WAD3, %dx%d\n", mt->name, mt->width, mt->height);		// didn't find the texture in the folder
+				Con_DPrintf("Loading texture %s as WAD3, %dx%d\n", mt->name, mt->width, mt->height);		// didn't find the texture in the folder
 					
 				// naievil -- try to push wad3 loading 
 				int index = WAD3_LoadTexture(mt);

--- a/source/psp/video_hardware_model.cpp
+++ b/source/psp/video_hardware_model.cpp
@@ -560,53 +560,24 @@ void Mod_LoadTextures (lump_t *l)
 	{
 		if (loadmodel->bspversion == HL_BSPVERSION || loadmodel->bspversion == NZP_BSPVERSION)
 		{
-			
-			// char filename[64];		// Filename to check r4w file
-			// byte *f;
-			// sprintf(filename, "textures/maps/%s/%s.r4w", sv.name, mt->name);		// search in textures/maps/MAPNAME/TEXNAME
-			
-			// f = static_cast<byte*>(COM_LoadHunkFile(filename));
-			
-			// if (!f) {
-			// 	sprintf(filename, "textures/%s.r4w", mt->name);					// search in textures/TEXNAME
-			// 	f = static_cast<byte*>(COM_LoadHunkFile(filename));
-			// }
-			
-			// if (!f) {
-				Con_DPrintf("Loading texture %s as WAD3, %dx%d\n", mt->name, mt->width, mt->height);		// didn't find the texture in the folder
+			Con_DPrintf("Loading texture %s as WAD3, %dx%d\n", mt->name, mt->width, mt->height);		// didn't find the texture in the folder
 					
-				// naievil -- try to push wad3 loading 
-				int index = WAD3_LoadTexture(mt);
-				if(index)
-				{
-					com_netpath[0] = 0;
-					tx->gl_texturenum = index;
-					tx->fullbright = -1;
-					mapTextureNameList.push_back(tx->gl_texturenum);
-					tx->dt_texturenum = 0;
-				}
-				else
-				{
-					Con_Printf("Texture %s not found\n", mt->name);		// didn't find the texture in the folder
-					com_netpath[0] = 0;
-					tx->gl_texturenum = nonetexture;
-				}
-			
-			// } else {
-				
-			// 	int w, h;
-				
-			// 	unsigned int magic = *((unsigned int*)(f));
-			// 	if (magic == 0x65663463)								// what the fuck? 
-			// 	{
-			// 		w = *((int*)(f + 4));
-			// 		h = *((int*)(f + 8));
-
-			// 		tx->gl_texturenum = GL_LoadTexture4(mt->name, w, h, (byte*)(f + 16), GU_LINEAR, qfalse);
-			// 		mapTextureNameList.push_back(tx->gl_texturenum);
-			// 	}
-	
-			// }
+			// naievil -- try to push wad3 loading 
+			int index = WAD3_LoadTexture(mt);
+			if(index)
+			{
+				com_netpath[0] = 0;
+				tx->gl_texturenum = index;
+				tx->fullbright = -1;
+				mapTextureNameList.push_back(tx->gl_texturenum);
+				tx->dt_texturenum = 0;
+			}
+			else
+			{
+				Con_Printf("Texture %s not found\n", mt->name);		// didn't find the texture in the folder
+				com_netpath[0] = 0;
+				tx->gl_texturenum = nonetexture;
+			}
 		}
 		else
 		{

--- a/source/psp/video_hardware_model.cpp
+++ b/source/psp/video_hardware_model.cpp
@@ -561,18 +561,18 @@ void Mod_LoadTextures (lump_t *l)
 		if (loadmodel->bspversion == HL_BSPVERSION || loadmodel->bspversion == NZP_BSPVERSION)
 		{
 			
-			char filename[64];		// Filename to check r4w file
-			byte *f;
-			sprintf(filename, "textures/maps/%s/%s.r4w", sv.name, mt->name);		// search in textures/maps/MAPNAME/TEXNAME
+			// char filename[64];		// Filename to check r4w file
+			// byte *f;
+			// sprintf(filename, "textures/maps/%s/%s.r4w", sv.name, mt->name);		// search in textures/maps/MAPNAME/TEXNAME
 			
-			f = static_cast<byte*>(COM_LoadHunkFile(filename));
+			// f = static_cast<byte*>(COM_LoadHunkFile(filename));
 			
-			if (!f) {
-				sprintf(filename, "textures/%s.r4w", mt->name);					// search in textures/TEXNAME
-				f = static_cast<byte*>(COM_LoadHunkFile(filename));
-			}
+			// if (!f) {
+			// 	sprintf(filename, "textures/%s.r4w", mt->name);					// search in textures/TEXNAME
+			// 	f = static_cast<byte*>(COM_LoadHunkFile(filename));
+			// }
 			
-			if (!f) {
+			// if (!f) {
 				Con_DPrintf("Loading texture %s as WAD3, %dx%d\n", mt->name, mt->width, mt->height);		// didn't find the texture in the folder
 					
 				// naievil -- try to push wad3 loading 
@@ -584,15 +584,6 @@ void Mod_LoadTextures (lump_t *l)
 					tx->fullbright = -1;
 					mapTextureNameList.push_back(tx->gl_texturenum);
 					tx->dt_texturenum = 0;
-
-	//				if(tx_pixels = WAD3_LoadTexture(mt))
-	//				{
-	//					com_netpath[0] = 0;
-	//					tx->gl_texturenum = GL_LoadPalletedTexture (tx_pixels, tx->name, tx->width, tx->height, 0);
-	//					tx->fullbright = -1;
-	//					mapTextureNameList.push_back(tx->gl_texturenum);
-	//					tx->dt_texturenum = 0;
-
 				}
 				else
 				{
@@ -601,37 +592,31 @@ void Mod_LoadTextures (lump_t *l)
 					tx->gl_texturenum = nonetexture;
 				}
 			
-			} else {
+			// } else {
 				
-				int w, h;
+			// 	int w, h;
 				
-				unsigned int magic = *((unsigned int*)(f));
-				if (magic == 0x65663463)								// what the fuck? 
-				{
-					w = *((int*)(f + 4));
-					h = *((int*)(f + 8));
+			// 	unsigned int magic = *((unsigned int*)(f));
+			// 	if (magic == 0x65663463)								// what the fuck? 
+			// 	{
+			// 		w = *((int*)(f + 4));
+			// 		h = *((int*)(f + 8));
 
-					tx->gl_texturenum = GL_LoadTexture4(mt->name, w, h, (byte*)(f + 16), GU_LINEAR, qfalse);
-					mapTextureNameList.push_back(tx->gl_texturenum);
-				}
+			// 		tx->gl_texturenum = GL_LoadTexture4(mt->name, w, h, (byte*)(f + 16), GU_LINEAR, qfalse);
+			// 		mapTextureNameList.push_back(tx->gl_texturenum);
+			// 	}
 	
-			}
+			// }
 		}
 		else
 		{
 			sprintf (texname, "textures/%s", mt->name);
-			tx->gl_texturenum = loadtextureimage (texname, 0, 0, qfalse, GU_LINEAR);
+			tx->gl_texturenum = loadtextureimage (texname, 0, 0, qfalse, GU_LINEAR, 0);
 			if(tx->gl_texturenum == 0)
 			{
 				tx->gl_texturenum = GL_LoadTexture (mt->name, tx->width, tx->height, (byte *)(tx_pixels), qtrue, GU_LINEAR, level);
 			}
 			mapTextureNameList.push_back(tx->gl_texturenum);
-/*
-		          //Crow_bar mult detail textures
-				  sprintf (detname, "gfx/detail/%s", mt->name);
-			      tx->dt_texturenum = loadtextureimage (detname, 0, 0, qfalse, GU_LINEAR);
-			      mapTextureNameList.push_back(tx->dt_texturenum);
-*/
 			tx->dt_texturenum = 0;
 		          // check for fullbright pixels in the texture - only if it ain't liquid, etc also
 			if ((tx->name[0] != '*') && (FindFullbrightTexture ((byte *)(tx_pixels), pixels)))
@@ -2156,7 +2141,7 @@ void *Mod_LoadAllSkins (int numskins, daliasskintype_t *pskintype)
 			pheader->gl_texturenum[i][0] = 
 			pheader->gl_texturenum[i][1] = 
 			pheader->gl_texturenum[i][2] = 
-			pheader->gl_texturenum[i][3] = loadtextureimage("models/weapons/m1911/v_biatch.mdl_0", 0, 0, qtrue, GU_LINEAR);
+			pheader->gl_texturenum[i][3] = loadtextureimage("models/weapons/m1911/v_biatch.mdl_0", 0, 0, qtrue, GU_LINEAR, 1);
 
 			pskintype = (daliasskintype_t *)((byte *)(pskintype+1) + s);
 			return (void *)pskintype;
@@ -2169,7 +2154,7 @@ void *Mod_LoadAllSkins (int numskins, daliasskintype_t *pskintype)
 					pheader->gl_texturenum[i][0] =
 					pheader->gl_texturenum[i][1] =
 					pheader->gl_texturenum[i][2] =
-					pheader->gl_texturenum[i][3] = loadtextureimage("models/machines/v_perk.mdl_0", 0, 0, qtrue, GU_LINEAR);
+					pheader->gl_texturenum[i][3] = loadtextureimage("models/machines/v_perk.mdl_0", 0, 0, qtrue, GU_LINEAR, 1);
 					pskintype = (daliasskintype_t *)((byte *)(pskintype+1) + s);
 					mapTextureNameList.push_back(pheader->gl_texturenum[i][i]); 
 				} else if (!has_perk_revive && i == 0) {
@@ -2184,7 +2169,7 @@ void *Mod_LoadAllSkins (int numskins, daliasskintype_t *pskintype)
 					pheader->gl_texturenum[i][0] =
 					pheader->gl_texturenum[i][1] =
 					pheader->gl_texturenum[i][2] =
-					pheader->gl_texturenum[i][3] = loadtextureimage("models/machines/v_perk.mdl_1", 0, 0, qtrue, GU_LINEAR);
+					pheader->gl_texturenum[i][3] = loadtextureimage("models/machines/v_perk.mdl_1", 0, 0, qtrue, GU_LINEAR, 1);
 					pskintype = (daliasskintype_t *)((byte *)(pskintype+1) + s);
 					mapTextureNameList.push_back(pheader->gl_texturenum[i][i]); 
 				} else if (!has_perk_juggernog && i == 1) {
@@ -2199,7 +2184,7 @@ void *Mod_LoadAllSkins (int numskins, daliasskintype_t *pskintype)
 					pheader->gl_texturenum[i][0] =
 					pheader->gl_texturenum[i][1] =
 					pheader->gl_texturenum[i][2] =
-					pheader->gl_texturenum[i][3] = loadtextureimage("models/machines/v_perk.mdl_2", 0, 0, qtrue, GU_LINEAR);
+					pheader->gl_texturenum[i][3] = loadtextureimage("models/machines/v_perk.mdl_2", 0, 0, qtrue, GU_LINEAR, 1);
 					pskintype = (daliasskintype_t *)((byte *)(pskintype+1) + s);
 					mapTextureNameList.push_back(pheader->gl_texturenum[i][i]); 
 				} else if (!has_perk_speedcola && i == 2) {
@@ -2214,7 +2199,7 @@ void *Mod_LoadAllSkins (int numskins, daliasskintype_t *pskintype)
 					pheader->gl_texturenum[i][0] =
 					pheader->gl_texturenum[i][1] =
 					pheader->gl_texturenum[i][2] =
-					pheader->gl_texturenum[i][3] = loadtextureimage("models/machines/v_perk.mdl_3", 0, 0, qtrue, GU_LINEAR);
+					pheader->gl_texturenum[i][3] = loadtextureimage("models/machines/v_perk.mdl_3", 0, 0, qtrue, GU_LINEAR, 1);
 					pskintype = (daliasskintype_t *)((byte *)(pskintype+1) + s);
 					mapTextureNameList.push_back(pheader->gl_texturenum[i][i]); 
 				} else if (!has_perk_doubletap && i == 3) {
@@ -2229,7 +2214,7 @@ void *Mod_LoadAllSkins (int numskins, daliasskintype_t *pskintype)
 					pheader->gl_texturenum[i][0] =
 					pheader->gl_texturenum[i][1] =
 					pheader->gl_texturenum[i][2] =
-					pheader->gl_texturenum[i][3] = loadtextureimage("models/machines/v_perk.mdl_4", 0, 0, qtrue, GU_LINEAR);
+					pheader->gl_texturenum[i][3] = loadtextureimage("models/machines/v_perk.mdl_4", 0, 0, qtrue, GU_LINEAR, 1);
 					pskintype = (daliasskintype_t *)((byte *)(pskintype+1) + s);
 					mapTextureNameList.push_back(pheader->gl_texturenum[i][i]); 
 				} else if (!has_perk_staminup && i == 4) {
@@ -2244,7 +2229,7 @@ void *Mod_LoadAllSkins (int numskins, daliasskintype_t *pskintype)
 					pheader->gl_texturenum[i][0] =
 					pheader->gl_texturenum[i][1] =
 					pheader->gl_texturenum[i][2] =
-					pheader->gl_texturenum[i][3] = loadtextureimage("models/machines/v_perk.mdl_5", 0, 0, qtrue, GU_LINEAR);
+					pheader->gl_texturenum[i][3] = loadtextureimage("models/machines/v_perk.mdl_5", 0, 0, qtrue, GU_LINEAR, 1);
 					pskintype = (daliasskintype_t *)((byte *)(pskintype+1) + s);
 					mapTextureNameList.push_back(pheader->gl_texturenum[i][i]); 
 				} else if (!has_perk_flopper && i == 5) {
@@ -2259,7 +2244,7 @@ void *Mod_LoadAllSkins (int numskins, daliasskintype_t *pskintype)
 					pheader->gl_texturenum[i][0] =
 					pheader->gl_texturenum[i][1] =
 					pheader->gl_texturenum[i][2] =
-					pheader->gl_texturenum[i][3] = loadtextureimage("models/machines/v_perk.mdl_6", 0, 0, qtrue, GU_LINEAR);
+					pheader->gl_texturenum[i][3] = loadtextureimage("models/machines/v_perk.mdl_6", 0, 0, qtrue, GU_LINEAR, 1);
 					pskintype = (daliasskintype_t *)((byte *)(pskintype+1) + s);
 					mapTextureNameList.push_back(pheader->gl_texturenum[i][i]); 
 				} else if (!has_perk_deadshot && i == 6) {
@@ -2274,7 +2259,7 @@ void *Mod_LoadAllSkins (int numskins, daliasskintype_t *pskintype)
 					pheader->gl_texturenum[i][0] =
 					pheader->gl_texturenum[i][1] =
 					pheader->gl_texturenum[i][2] =
-					pheader->gl_texturenum[i][3] = loadtextureimage("models/machines/v_perk.mdl_7", 0, 0, qtrue, GU_LINEAR);
+					pheader->gl_texturenum[i][3] = loadtextureimage("models/machines/v_perk.mdl_7", 0, 0, qtrue, GU_LINEAR, 1);
 					pskintype = (daliasskintype_t *)((byte *)(pskintype+1) + s);
 					mapTextureNameList.push_back(pheader->gl_texturenum[i][i]); 
 				} else if (!has_perk_mulekick && i == 7) {
@@ -2306,7 +2291,7 @@ void *Mod_LoadAllSkins (int numskins, daliasskintype_t *pskintype)
 			pheader->gl_texturenum[i][0] = 
 			pheader->gl_texturenum[i][1] = 
 			pheader->gl_texturenum[i][2] = 
-			pheader->gl_texturenum[i][3] = loadtextureimage("models/weapons/v_papskin", 0, 0, qtrue, GU_LINEAR);
+			pheader->gl_texturenum[i][3] = loadtextureimage("models/weapons/v_papskin", 0, 0, qtrue, GU_LINEAR, 1);
 			pskintype = (daliasskintype_t *)((byte *)(pskintype+1) + s);
 			return (void *)pskintype;
 		}
@@ -2323,7 +2308,7 @@ void *Mod_LoadAllSkins (int numskins, daliasskintype_t *pskintype)
 			pheader->gl_texturenum[i][0] = 
 			pheader->gl_texturenum[i][1] = 
 			pheader->gl_texturenum[i][2] = 
-			pheader->gl_texturenum[i][3] = loadtextureimage (model2, 0, 0, qtrue, GU_LINEAR);
+			pheader->gl_texturenum[i][3] = loadtextureimage (model2, 0, 0, qtrue, GU_LINEAR, 1);
 
 			if (pheader->gl_texturenum[i][0] == 0)// did not find a matching TGA...
 
@@ -2358,7 +2343,7 @@ void *Mod_LoadAllSkins (int numskins, daliasskintype_t *pskintype)
 				COM_StripExtension(loadmodel->name, model);
 				sprintf (model2, "%s_%i_%i", model, i, j);
 				pheader->gl_texturenum[i][j&3] =
-				loadtextureimage (model2, 0, 0, qfalse, GU_LINEAR);
+				loadtextureimage (model2, 0, 0, qfalse, GU_LINEAR, 1);
 				
 				if (pheader->gl_texturenum[i][j&3] == 0)// did not find a matching TGA...
 				{
@@ -2750,7 +2735,7 @@ void Mod_LoadH2AliasModel (model_t *mod, void *buffer)
 Mod_LoadQ2AliasModel
 =================
 */
-int loadtextureimage (char* filename, int matchwidth, int matchheight, qboolean complain, int filter);
+int loadtextureimage (char* filename, int matchwidth, int matchheight, qboolean complain, int filter, int type);
 
 void Mod_LoadQ2AliasModel (model_t *mod, void *buffer)
 {
@@ -2821,7 +2806,7 @@ void Mod_LoadQ2AliasModel (model_t *mod, void *buffer)
 		pinskins = static_cast<char*>((void*)((int) pinmodel + LittleLong(pinmodel->ofs_skins)));
 		for (i = 0;i < pheader->num_skins;i++)
 		{
-			pheader->gl_texturenum[i] = loadtextureimage (pinskins, 0, 0, qtrue, GU_LINEAR);
+			pheader->gl_texturenum[i] = loadtextureimage (pinskins, 0, 0, qtrue, GU_LINEAR, 0);
 			pinskins += MD2MAX_SKINNAME;
             /* Crow_bar Memory Leak Fixed                           */
 			mapTextureNameList.push_back(pheader->gl_texturenum[i]);
@@ -3073,22 +3058,22 @@ void Mod_LoadQ3ModelTexture (char *identifier, int flags, int *gl_texnum)
 	char	loadpath[64];
 
 	Q_snprintfz (loadpath, sizeof(loadpath), "textures/q3models/%s", identifier);
-	*gl_texnum = loadtextureimage (loadpath, 0, 0, qtrue, GU_LINEAR);
+	*gl_texnum = loadtextureimage (loadpath, 0, 0, qtrue, GU_LINEAR, 0);
 
 	if (!*gl_texnum)
 	{
 		Q_snprintfz (loadpath, sizeof(loadpath), "textures/%s", identifier);
-		*gl_texnum = loadtextureimage (loadpath, 0, 0, qtrue, GU_LINEAR);
+		*gl_texnum = loadtextureimage (loadpath, 0, 0, qtrue, GU_LINEAR, 0);
 	}
 	if (!*gl_texnum)
 	{
 		Q_snprintfz (loadpath, sizeof(loadpath), "progs/%s", identifier);
-		*gl_texnum = loadtextureimage (loadpath, 0, 0, qtrue, GU_LINEAR);
+		*gl_texnum = loadtextureimage (loadpath, 0, 0, qtrue, GU_LINEAR, 0);
 	}
 	if (!*gl_texnum)
 	{
 		Q_snprintfz (loadpath, sizeof(loadpath), "maps/%s", identifier);
-		*gl_texnum = loadtextureimage (loadpath, 0, 0, qtrue, GU_LINEAR);
+		*gl_texnum = loadtextureimage (loadpath, 0, 0, qtrue, GU_LINEAR, 0);
 	}
 
 	mapTextureNameList.push_back(*gl_texnum);
@@ -3629,7 +3614,7 @@ void * Mod_LoadSpriteFrame (void * pin, mspriteframe_t **ppframe, int framenum, 
 	{
 		COM_StripExtension(loadmodel->name, sprite);
 		sprintf (sprite2, "%s.spr_%i", sprite, framenum);
-		pspriteframe->gl_texturenum = loadtextureimage (sprite2, 0, 0, qtrue, GU_LINEAR);
+		pspriteframe->gl_texturenum = loadtextureimage (sprite2, 0, 0, qtrue, GU_LINEAR, 0);
 		
 		if (pspriteframe->gl_texturenum == 0)// did not find a matching TGA...
 		{
@@ -3971,7 +3956,7 @@ qboolean Mod_LoadQ2SpriteModel (model_t *mod, void *buffer)
 
 		frame = psprite->frames[i].frameptr = static_cast<mspriteframe_t*>(Hunk_AllocName(sizeof(mspriteframe_t), loadname));
 
-		frame->gl_texturenum = loadtextureimage (pframetype->name, 0, 0, qtrue, GU_LINEAR);
+		frame->gl_texturenum = loadtextureimage (pframetype->name, 0, 0, qtrue, GU_LINEAR, 0);
         mapTextureNameList.push_back(frame->gl_texturenum);
 
 		frame->width = LittleLong(pframetype->width);

--- a/source/psp/video_hardware_screen.cpp
+++ b/source/psp/video_hardware_screen.cpp
@@ -1048,7 +1048,7 @@ void SCR_DrawLoadScreen (void)
 			strcpy(lpath, "gfx/lscreen/");
 			strcat(lpath, loadname2);
 
-			lscreen = Draw_CachePic(lpath);
+			lscreen = Draw_CacheImg(lpath);
 			awoo = Draw_CacheImg("gfx/menu/awoo");
 
 			if (lscreen != NULL)

--- a/source/psp/video_hardware_warp.cpp
+++ b/source/psp/video_hardware_warp.cpp
@@ -914,11 +914,11 @@ void Sky_LoadSkyBox (char *name)
     {
         int mark = Hunk_LowMark ();
 
-		if(!(skyimage[i] = loadtextureimage (va("gfx/env/%s%s", name, suf[i]), 0, 0, qfalse, GU_LINEAR)) &&
-           !(skyimage[i] = loadtextureimage (va("gfx/env/%s_%s", name, suf[i]), 0, 0, qfalse, GU_LINEAR)))
+		if(!(skyimage[i] = loadtextureimage (va("gfx/env/%s%s", name, suf[i]), 0, 0, qfalse, GU_LINEAR, 0)) &&
+           !(skyimage[i] = loadtextureimage (va("gfx/env/%s_%s", name, suf[i]), 0, 0, qfalse, GU_LINEAR, 0)))
 		{
 			Con_Printf("Sky: %s[%s] not found, used std\n", name, suf[i]);
-		    if(!(skyimage[i] = loadtextureimage (va("gfx/env/skybox%s", suf[i]), 0, 0, qfalse, GU_LINEAR)))
+		    if(!(skyimage[i] = loadtextureimage (va("gfx/env/skybox%s", suf[i]), 0, 0, qfalse, GU_LINEAR, 0)))
 		    {
 			    Sys_Error("STD SKY NOT FOUND!");
 			}


### PR DESCRIPTION
lots of small smart hacks like limiting file I/O checks to give up if a PCX isnt found for MDLs, removing unused external texture check for WAD3 substitutions, removing .BMP support, getting rid of useless debug console prints.