### PR TITLE
Simplify resource management

### DIFF
--- a/source/draw.h
+++ b/source/draw.h
@@ -25,6 +25,7 @@ void Draw_Init (void);
 void Draw_Character (int x, int y, int num);
 void Draw_DebugChar (char num);
 void Draw_Pic (int x, int y, qpic_t *pic);
+void Draw_PicIndex (int x, int y, int width, int height, int texture_index);
 void Draw_StretchPic (int x, int y, qpic_t *pic, int x_value, int y_value);
 void Draw_ColorPic (int x, int y, qpic_t *pic, float r, float g , float b, float a);
 void Draw_ColoredString (int x, int y, char *text, float r, float g, float b, float a, int scale);
@@ -47,6 +48,5 @@ extern int loading_step;
 extern char loading_name[32];
 extern float loading_num_step;
 
-qpic_t *Draw_PicFromWad (char *name);
 qpic_t *Draw_CachePic (char *path);
 qpic_t *Draw_CacheImg (char *path);

--- a/source/host.c
+++ b/source/host.c
@@ -704,7 +704,8 @@ void _Host_Frame (float time)
 					pass1+pass2+pass3, pass1, pass2, pass3);
 	}
 
-	// if ((host_framecount % 120) == 0) Con_Printf ("%dkB free \n", pspSdkTotalFreeUserMemSize()/1024);
+	// Debug log free memory
+	// if ((host_framecount % 120) == 0) Con_Printf ("%.2fkB free \n", pspSdkTotalFreeUserMemSize()/1024.f);
 
 	//frame speed counter
 	fps_count++;//muff

--- a/source/host.c
+++ b/source/host.c
@@ -498,8 +498,6 @@ void Host_ClearMemory (void)
 {
 	Con_DPrintf ("Clearing memory\n");
 
-	D_FlushCaches ();
-
 	Mod_ClearAll ();
 
 	if (host_hunklevel)
@@ -706,7 +704,7 @@ void _Host_Frame (float time)
 					pass1+pass2+pass3, pass1, pass2, pass3);
 	}
 
-    //Con_Printf ("%dkB free \n", pspSdkTotalFreeUserMemSize()/1024);
+	// if ((host_framecount % 120) == 0) Con_Printf ("%dkB free \n", pspSdkTotalFreeUserMemSize()/1024);
 
 	//frame speed counter
 	fps_count++;//muff

--- a/source/psp/video_hardware.h
+++ b/source/psp/video_hardware.h
@@ -56,6 +56,8 @@ int GL_LoadPalTex (const char *identifier, int width, int height, const byte *da
 int GL_LoadPalletedTexture (byte *in, char *identifier, int width, int height, int mode);
 
 void GL_UnloadTexture (const int texture_index);
+void GL_UnloadAllTextures ();
+void GL_MarkTextureAsPermanent (const int texture_index);
 
 extern	int glx, gly, glwidth, glheight;
 
@@ -169,7 +171,6 @@ typedef struct particle2_s
 
 
 extern	entity_t	r_worldentity;
-extern	qboolean	r_cache_thrash;		// compatability
 extern	vec3_t		modelorg, r_entorigin;
 extern	entity_t	*currententity;
 extern	int			r_visframecount;	// ??? what difs?

--- a/source/psp/video_hardware_QMB.cpp
+++ b/source/psp/video_hardware_QMB.cpp
@@ -450,6 +450,8 @@ void QMB_InitParticles (void)
 		return;
 	}
 
+	GL_MarkTextureAsPermanent(particleimage);
+
 	loading_cur_step++;
 	strcpy(loading_name, "Particles");
 	SCR_UpdateScreen ();
@@ -476,6 +478,8 @@ void QMB_InitParticles (void)
 		//Clear_LoadingFill ();
 		return;
 	}
+
+	GL_MarkTextureAsPermanent(particleimage);
 	
 	max_s = 384.0; max_t = 192.0;
 	for (i = 0, ti = 0 ; i < 2 ; i++)
@@ -501,6 +505,8 @@ void QMB_InitParticles (void)
 		//Clear_LoadingFill ();
 		return;
 	}
+
+	GL_MarkTextureAsPermanent(particleimage);
 	
 	/*max_s = max_t = 128.0;
 	for (i = 0, ti = 0 ; i < 2 ; i++)
@@ -516,6 +522,9 @@ void QMB_InitParticles (void)
 		//Clear_LoadingFill ();
 		return;
 	}
+
+	GL_MarkTextureAsPermanent(particleimage);
+
     max_s = max_t = 256.0;
 	ADD_PARTICLE_TEXTURE(ptex_flame, particleimage, 0, 1, 0, 0, 256, 256);
 
@@ -527,6 +536,8 @@ void QMB_InitParticles (void)
         //Clear_LoadingFill ();
 		return;
 	}
+
+	GL_MarkTextureAsPermanent(particleimage);
 
 	max_s = 256.0; max_t = 128.0;
 	ADD_PARTICLE_TEXTURE(ptex_lightning, particleimage, 0, 1, 0, 0, 256, 128);//R00k changed
@@ -540,6 +551,9 @@ void QMB_InitParticles (void)
 		//Clear_LoadingFill ();
 		return;
 	}
+
+	GL_MarkTextureAsPermanent(particleimage);
+
 	//max_s = max_t = 256.0;
 	ADD_PARTICLE_TEXTURE(ptex_muzzleflash, particleimage, 0, 1, 0, 0, 128, 128);
 
@@ -555,6 +569,9 @@ void QMB_InitParticles (void)
 		//Clear_LoadingFill ();
 		return;
 	}
+
+	GL_MarkTextureAsPermanent(particleimage);
+
 	//max_s = max_t = 256.0;
 	ADD_PARTICLE_TEXTURE(ptex_muzzleflash2, particleimage, 0, 1, 0, 0, 128, 128);
 
@@ -565,6 +582,9 @@ void QMB_InitParticles (void)
         //Clear_LoadingFill ();
 		return;
 	}
+
+	GL_MarkTextureAsPermanent(particleimage);
+
 	//max_s = max_t = 256.0;
 	ADD_PARTICLE_TEXTURE(ptex_muzzleflash3, particleimage, 0, 1, 0, 0, 128, 128);
 
@@ -579,6 +599,9 @@ void QMB_InitParticles (void)
         //Clear_LoadingFill ();
 		return;
 	}
+
+	GL_MarkTextureAsPermanent(particleimage);
+
 	//max_s = max_t = 256.0;
 	ADD_PARTICLE_TEXTURE(ptex_bloodcloud, particleimage, 0, 1, 0, 0, 64, 64);
 

--- a/source/psp/video_hardware_draw.cpp
+++ b/source/psp/video_hardware_draw.cpp
@@ -47,7 +47,6 @@ qpic_t		*sniper_scope;
 
 int			translate_texture;
 int			char_texture;
-int			detail_texture;
 //int			zombie_skins[3][8];
 int			zombie_skins[2][2];
 int         ref_texture;
@@ -101,6 +100,7 @@ void VID_SetPalette4(unsigned char* clut4pal);
 #define	MAX_GLTEXTURES	1024
 gltexture_t	gltextures[MAX_GLTEXTURES];
 bool 		gltextures_used[MAX_GLTEXTURES];
+bool 		gltextures_is_permanent[MAX_GLTEXTURES];
 int			numgltextures;
 
 typedef struct
@@ -131,6 +131,7 @@ void GL_InitTextureUsage ()
 {
 	for (int i=0; i<MAX_GLTEXTURES; i++) {
 		gltextures_used[i] = false;
+		gltextures_is_permanent[i] = false;
 	}
 	numgltextures = 0;
 }
@@ -323,19 +324,6 @@ static int GL_LoadPicTexture (qpic_t *pic)
 	return GL_LoadTexture ("", pic->width, pic->height, pic->data, qfalse, GU_NEAREST, 0);
 }
 
-qpic_t *Draw_PicFromWad (char *name)
-{
-	qpic_t	*p;
-	glpic_t	*gl;
-
-	p = static_cast<qpic_t*>(W_GetLumpName (name));
-	gl = (glpic_t *)p->data;
-	gl->index = GL_LoadPicTexture (p);
-
-	return p;
-}
-
-
 /*
 ================
 Draw_CachePic
@@ -372,7 +360,8 @@ qpic_t	*Draw_CachePic (char *path)
 		gltextures[index].islmp = qfalse;
 		gl = (glpic_t *)pic->pic.data;
 		gl->index = index;
-
+		GL_MarkTextureAsPermanent(gl->index);
+	
 		return &pic->pic;
 	}
 
@@ -395,6 +384,7 @@ qpic_t	*Draw_CachePic (char *path)
 
 	gl = (glpic_t *)pic->pic.data;
 	gl->index = GL_LoadPicTexture (dat);
+	GL_MarkTextureAsPermanent(gl->index);
 
 	gltextures[gl->index].islmp = qtrue;
 	return &pic->pic;
@@ -402,7 +392,7 @@ qpic_t	*Draw_CachePic (char *path)
 
 /*
 ================
-Draw_CachePic
+Draw_CacheImg
 ================
 */
 qpic_t	*Draw_CacheImg (char *path)
@@ -433,6 +423,7 @@ qpic_t	*Draw_CacheImg (char *path)
 
 		gl = (glpic_t *)pic->pic.data;
 		gl->index = index;
+		GL_MarkTextureAsPermanent(gl->index);
 
 		return &pic->pic;
 	}
@@ -453,6 +444,7 @@ qpic_t	*Draw_CacheImg (char *path)
 
 	gl = (glpic_t *)pic->pic.data;
 	gl->index = GL_LoadPicTexture (dat);
+	GL_MarkTextureAsPermanent(gl->index);
 
 	return &pic->pic;
 }
@@ -528,32 +520,20 @@ void Draw_Init (void)
 	// it into a texture
 
 	nonetexture = GL_LoadTexture ("nonetexture", 8, 8, (byte*)nontexdt, qfalse, GU_NEAREST, 0);
+	GL_MarkTextureAsPermanent(nonetexture);
 	R_CreateDlightImage();
 
 	// now turn them into textures
 	char_texture = loadtextureimage ("gfx/charset", 0, 0, qfalse, GU_NEAREST);
+	GL_MarkTextureAsPermanent(char_texture);
 	if (char_texture == 0)// did not find a matching TGA...
 		Sys_Error ("Could not load charset, make sure you have every folder and file installed properly\nDouble check that all of your files are in their correct places\nAnd that you have installed the game properly.\nRefer to the readme.txt file for help\n");
 
-	detail_texture = loadtextureimage ("gfx/detail", 0, 0, qfalse, GU_LINEAR);
-
-	if (detail_texture == 0)// did not find a matching TGA...
-	{
-		detail = static_cast<byte*>(COM_LoadTempFile ("gfx/detail.lmp"));
-		if (!detail)
-		{
-			//Con_Printf ("Couldn't load gfx/detail \n"); FIXME no point?
-			detail_texture = nonetexture;
-		}
-		else
-			detail_texture = GL_LoadTexture ("Detail", 256, 256, detail, qfalse, GU_LINEAR, 3);
-	}
-
 	sniper_scope = Draw_CachePic ("gfx/hud/scope_256");
-	
+	// GL_MarkTextureAsPermanent(sniper_scope);
+
 	zombie_skins[0][0] = loadtextureimage ("models/ai/zfull.mdl_0", 0, 0, qtrue, GU_LINEAR);
-
-
+	GL_MarkTextureAsPermanent(zombie_skins[0][0]);
 	// PSP PHAT: Only have 1 Zombie skin.. this saves 192kB of VRAM, well worth it.
 
 #ifdef SLIM
@@ -561,13 +541,13 @@ void Draw_Init (void)
 	zombie_skins[0][1] = loadtextureimage ("models/ai/zfull.mdl_1", 0, 0, qtrue, GU_LINEAR);
 	zombie_skins[1][0] = loadtextureimage ("models/ai/zfull.mdl_2", 0, 0, qtrue, GU_LINEAR);
 	zombie_skins[1][1] = loadtextureimage ("models/ai/zfull.mdl_3", 0, 0, qtrue, GU_LINEAR);
-
+	GL_MarkTextureAsPermanent(zombie_skins[0][1]);
+	GL_MarkTextureAsPermanent(zombie_skins[1][0]);
+	GL_MarkTextureAsPermanent(zombie_skins[1][1]);
 #else
-
-	zombie_skins[0][1] = loadtextureimage ("models/ai/zfull.mdl_0", 0, 0, qtrue, GU_LINEAR);
-	zombie_skins[1][0] = loadtextureimage ("models/ai/zfull.mdl_0", 0, 0, qtrue, GU_LINEAR);
-	zombie_skins[1][1] = loadtextureimage ("models/ai/zfull.mdl_0", 0, 0, qtrue, GU_LINEAR);
-
+	zombie_skins[0][1] = zombie_skins[0][0];
+	zombie_skins[1][0] = zombie_skins[0][0];
+	zombie_skins[1][1] = zombie_skins[0][0];
 #endif // SLIM
 	
 	Clear_LoadingFill ();
@@ -759,6 +739,53 @@ void Draw_AlphaPic (int x, int y, qpic_t *pic, float alpha)
 		sceGuTexFunc(GU_TFX_REPLACE, GU_TCC_RGBA);
 	}
 }
+
+/*
+=============
+Draw_AlphaPicIndex
+=============
+*/
+void Draw_PicIndex (int x, int y, int width, int height, int texture_index)
+{
+	GL_Bind(texture_index);
+
+	struct vertex
+	{
+		short			u, v;
+		short			x, y, z;
+	};
+
+	vertex* const vertices = static_cast<vertex*>(sceGuGetMemory(sizeof(vertex) * 2));
+
+   	vertices[0].u		= 0;
+	vertices[0].v		= 0;
+	vertices[0].x		= x;
+	vertices[0].y		= y;
+	vertices[0].z		= 0;
+
+	const gltexture_t& glt = gltextures[texture_index];
+	if (gltextures[texture_index].islmp)
+	{
+		vertices[1].u	= glt.original_width;
+		vertices[1].v	= glt.original_height;
+	}
+	else
+	{
+		vertices[1].u 	= glt.width;
+		vertices[1].v 	= glt.height;
+	}
+	vertices[1].x		= x + width;
+	vertices[1].y		= y + height;
+	vertices[1].z		= 0;
+
+	sceGuColor(0xffffffff);
+
+	sceGuDrawArray(
+		GU_SPRITES,
+		GU_TEXTURE_16BIT | GU_VERTEX_16BIT | GU_TRANSFORM_2D,
+		2, 0, vertices);
+}
+
 
 
 /*
@@ -2464,66 +2491,84 @@ GL_UnloadTexture
 */
 void GL_UnloadTexture(int texture_index)
 {
-	if (gltextures_used[texture_index] == true)
-	{
-		gltexture_t& texture = gltextures[texture_index];
+	if (gltextures_used[texture_index] == false) return;
+	if (gltextures_is_permanent[texture_index]) return;
 
-		Con_DPrintf("Unloading: %s,%d\n",texture.identifier, texture.bpp);
-		// Source.
-		strcpy(texture.identifier,"");
-		texture.original_width = 0;
-		texture.original_height = 0;
-		texture.stretch_to_power_of_two = qfalse;
+	gltexture_t& texture = gltextures[texture_index];
 
-        // Fill in the texture description.
-		texture.format  = GU_PSM_T8;
-        texture.bpp     = 0;
-		texture.filter  = GU_LINEAR;
-		texture.width   = 0;
-		texture.height  = 0;
-		texture.mipmaps = 0;
-		texture.swizzle = 0;
+	// Con_Printf("Unloading: %s,%d\n",texture.identifier, texture.bpp);
+	// Source.
+	strcpy(texture.identifier,"");
+	texture.original_width = 0;
+	texture.original_height = 0;
+	texture.stretch_to_power_of_two = qfalse;
+
+	// Fill in the texture description.
+	texture.format  = GU_PSM_T8;
+	texture.bpp     = 0;
+	texture.filter  = GU_LINEAR;
+	texture.width   = 0;
+	texture.height  = 0;
+	texture.mipmaps = 0;
+	texture.swizzle = 0;
 #ifdef STATIC_PAL
-		memset(texture.palette, 0, sizeof(texture.palette));
+	memset(texture.palette, 0, sizeof(texture.palette));
 #else
-        if (texture.palette != NULL)
-		{
-            free(texture.palette);
-            texture.palette = NULL;
-        }
-		if (texture.palette_2 != NULL)
-		{
-            free(texture.palette_2);
-            texture.palette_2 = NULL;
-        }
-#endif
-		texture.palette_active = qfalse;
-		if (texture.palette != NULL)
-		{
-			free(texture.palette);
-			texture.palette = NULL;
-		}
-		if (texture.palette_2 != NULL)
-		{
-			free(texture.palette_2);
-			texture.palette_2 = NULL;
-		}
-		
-		// Buffers.
-		if (texture.ram != NULL)
-		{
-			free(texture.ram);
-			texture.ram = NULL;
-		}
-		if (texture.vram != NULL)
-		{
-			vfree(texture.vram);
-			texture.vram = NULL;
-		}
-
-		gltextures_used[texture_index] = false;
-		numgltextures--;
+	if (texture.palette != NULL)
+	{
+		free(texture.palette);
+		texture.palette = NULL;
 	}
+	if (texture.palette_2 != NULL)
+	{
+		free(texture.palette_2);
+		texture.palette_2 = NULL;
+	}
+#endif
+	texture.palette_active = qfalse;
+	if (texture.palette != NULL)
+	{
+		free(texture.palette);
+		texture.palette = NULL;
+	}
+	if (texture.palette_2 != NULL)
+	{
+		free(texture.palette_2);
+		texture.palette_2 = NULL;
+	}
+	
+	// Buffers.
+	if (texture.ram != NULL)
+	{
+		free(texture.ram);
+		texture.ram = NULL;
+	}
+	if (texture.vram != NULL)
+	{
+		vfree(texture.vram);
+		texture.vram = NULL;
+	}
+
+	gltextures_used[texture_index] = false;
+	numgltextures--;
+}
+
+void GL_UnloadAllTextures() {
+	for (int i = 0; i < MAX_GLTEXTURES; i++) {
+		GL_UnloadTexture(i);
+	}
+}
+
+/*
+For marking textures as something that should never be cleaned up, like fonts, zombie, etc.
+There should never be need to change anything back from permanent.
+*/
+void GL_MarkTextureAsPermanent(int texture_index) {
+	if (gltextures_used[texture_index] == false) {
+		Sys_Error("Tried to mark an empty texture as permanent!\n");
+	}
+
+	gltextures_is_permanent[texture_index] = true;
 }
 
 int GL_TextureForName(const char * identifier) {
@@ -2568,7 +2613,6 @@ int GL_GetTextureIndex() {
 		Sys_Error("Could not find a free gl texture!\n");
 	}
 
-	Con_Printf("gltextures used %d\n", numgltextures);
 	gltextures_used[texture_index] = true;
 
 	return texture_index;
@@ -3176,6 +3220,7 @@ int GL_LoadImages (const char *identifier, int width, int height, const byte *da
 	//FIXME: this isn't completely clearing out the normal ram stuff :s
 	if (texture.vram && texture.ram)
 	{
+		Con_Printf("Put %s into VRAM (%dkB)\n", identifier, buffer_size/1024);
 		free(texture.ram);
 		texture.ram = NULL;
 	} else {

--- a/source/psp/video_hardware_hlmdl.cpp
+++ b/source/psp/video_hardware_hlmdl.cpp
@@ -31,8 +31,6 @@ extern"C"
 #include <pspgum.h>
 #include <list>
 
-extern std::list<int> mapTextureNameList;
-
 extern model_t	*loadmodel;
 
 extern vec3_t lightcolor; // LordHavoc: .lit support
@@ -157,9 +155,7 @@ qboolean Mod_LoadHLModel (model_t *mod, void *buffer)
 
 	for(i = 0; i < header->numtextures; i++)
     {
-
 		tex[i].i = GL_LoadPalTex (tex[i].name, tex[i].w, tex[i].h, (byte *) header + tex[i].i, qtrue, GU_LINEAR, 0, (byte *) header + tex[i].w * tex[i].h + tex[i].i, PAL_RGB);
-	    mapTextureNameList.push_back(tex[i].i); // for unload textures
 	}
 //
 // move the complete, relocatable alias model to the cache

--- a/source/psp/video_hardware_main.cpp
+++ b/source/psp/video_hardware_main.cpp
@@ -55,7 +55,6 @@ const float piconst = GU_PI / 180.0f;
 entity_t	r_worldentity;
 entity_t 	*currententity;
 
-qboolean	r_cache_thrash;		// compatability
 qboolean 	envmap;
 qboolean 	mirror;
 
@@ -3707,8 +3706,6 @@ void R_RenderScene (void)
 
 	V_SetContentsColor (r_viewleaf->contents);
 	V_CalcBlend ();
-
-	r_cache_thrash = qfalse;
 
 	c_brush_polys = 0;
 	c_alias_polys = 0;

--- a/source/psp/video_hardware_misc.cpp
+++ b/source/psp/video_hardware_misc.cpp
@@ -45,12 +45,19 @@ void	R_InitOtherTextures (void)
 {
 	//static decals
 	decal_blood1  = loadtextureimage ("textures/decals/blood_splat01", 0, 0, qfalse, GU_LINEAR);
+	GL_MarkTextureAsPermanent(decal_blood1);
 	decal_blood2  = loadtextureimage ("textures/decals/blood_splat02", 0, 0, qfalse, GU_LINEAR);
+	GL_MarkTextureAsPermanent(decal_blood2);
 	decal_blood3  = loadtextureimage ("textures/decals/blood_splat03", 0, 0, qfalse, GU_LINEAR);
+	GL_MarkTextureAsPermanent(decal_blood3);
     decal_q3blood = loadtextureimage ("textures/decals/blood_stain", 0, 0, qfalse, GU_LINEAR);
+	GL_MarkTextureAsPermanent(decal_blood1);
 	decal_burn	  = loadtextureimage ("textures/decals/explo_burn01", 0, 0, qfalse, GU_LINEAR);
+	GL_MarkTextureAsPermanent(decal_burn);
 	decal_mark	  = loadtextureimage ("textures/decals/particle_burn01", 0, 0, qfalse, GU_LINEAR);
+	GL_MarkTextureAsPermanent(decal_mark);
 	decal_glow	  = loadtextureimage ("textures/decals/glow2", 0, 0, qfalse, GU_LINEAR);
+	GL_MarkTextureAsPermanent(decal_glow);
 }
 
 /*
@@ -350,7 +357,7 @@ void R_Init (void)
 	Cvar_RegisterVariable (&r_runqmbparticles);
 
 	R_InitParticles ();
-	R_InitParticleTexture ();
+	// R_InitParticleTexture ();
 	R_InitOtherTextures ();
 	R_InitDecals ();
 	Sky_Init (); //johnfitz
@@ -450,9 +457,4 @@ void R_TimeRefresh_f (void)
 
 	GL_EndRendering ();
 }
-
-void D_FlushCaches (void)
-{
-}
-
 

--- a/source/psp/video_hardware_model.cpp
+++ b/source/psp/video_hardware_model.cpp
@@ -1214,6 +1214,7 @@ void Mod_LoadFaces (lump_t *l)
 	if (l->filelen % sizeof(*in))
 		Con_Printf ("MOD_LoadBmodel: funny lump size in %s",loadmodel->name);
 	count = l->filelen / sizeof(*in);
+	Con_Printf("Model faces %d\n", count);
 	out = static_cast<msurface_t*>(Hunk_AllocName ( count*sizeof(*out), loadname));
 
 	loadmodel->surfaces = out;

--- a/source/psp/video_hardware_model.cpp
+++ b/source/psp/video_hardware_model.cpp
@@ -1189,7 +1189,6 @@ void Mod_LoadFaces (lump_t *l)
 	if (l->filelen % sizeof(*in))
 		Con_Printf ("MOD_LoadBmodel: funny lump size in %s",loadmodel->name);
 	count = l->filelen / sizeof(*in);
-	Con_Printf("Model faces %d\n", count);
 	out = static_cast<msurface_t*>(Hunk_AllocName ( count*sizeof(*out), loadname));
 
 	loadmodel->surfaces = out;
@@ -2018,7 +2017,7 @@ void Mod_FloodFillSkin( byte *skin, int skinwidth, int skinheight )
 
 qboolean model_is_gun(char name[MAX_QPATH])
 {
-	char* wep_path = static_cast<char*>(malloc(sizeof(char)*15));
+	char wep_path[15];
 
 	for (int i = 0; i < 15; i++) {
 		wep_path[i] = name[i];

--- a/source/psp/video_hardware_model.cpp
+++ b/source/psp/video_hardware_model.cpp
@@ -36,10 +36,6 @@ extern "C"
 #include "video_hardware_hlmdl.h"
 #include "video_hardware_images.h"
 
-#include <list>
-
-std::list<int> mapTextureNameList;
-
 int LIGHTMAP_BYTES;
 
 model_t	*loadmodel;
@@ -227,32 +223,18 @@ void Mod_ClearAll (void)
 
 	ent_file = NULL; //~~~~
 
-	// maybe we should check if it is new map or not
-	// (so we dont unload textures unnecessary)
-	while (mapTextureNameList.size() > 0)
-	{
-		texture_index = mapTextureNameList.front();
-		mapTextureNameList.pop_front();
-		GL_UnloadTexture(texture_index);
-	}
+	GL_UnloadAllTextures();
+
 	solidskytexture	= -1;
 	alphaskytexture	= -1;
 
 	//purge old sky textures
 	for (i=0; i<6; i++)
-	{
-	    if (skyimage[i] && skyimage[i] != solidskytexture)
-            GL_UnloadTexture(skyimage[i]);
 		skyimage[i] = NULL;
-	}
 
 	//purge old lightmaps
 	for (i=0; i<MAX_LIGHTMAPS; i++)
-	{
-	    if (lightmap_index[i] && lightmap_index[i] != 0)
-            GL_UnloadTexture(lightmap_index[i]);
 		lightmap_index[i] = NULL;
-	}
 }
 
 /*
@@ -474,7 +456,6 @@ int GL_LoadTexturePixels (byte *data, char *identifier, int width, int height, i
 							 (loadmodel->bspversion == HL_BSPVERSION && (name)[0] == '!') ||	\
 							 (loadmodel->bspversion == NZP_BSPVERSION && (name)[0] == '!'))
 
-extern int detail_texture;
 extern int nonetexture;
 /*
 =================
@@ -553,8 +534,6 @@ void Mod_LoadTextures (lump_t *l)
     if (loadmodel->bspversion != HL_BSPVERSION && loadmodel->bspversion != NZP_BSPVERSION && ISSKYTEX(tx->name))
 	{
 		R_InitSky (tx_pixels);
-		mapTextureNameList.push_back(solidskytexture);
-		mapTextureNameList.push_back(alphaskytexture);
  	}
 	else
 	{
@@ -582,7 +561,6 @@ void Mod_LoadTextures (lump_t *l)
 					com_netpath[0] = 0;
 					tx->gl_texturenum = index;
 					tx->fullbright = -1;
-					mapTextureNameList.push_back(tx->gl_texturenum);
 					tx->dt_texturenum = 0;
 
 	//				if(tx_pixels = WAD3_LoadTexture(mt))
@@ -612,7 +590,6 @@ void Mod_LoadTextures (lump_t *l)
 					h = *((int*)(f + 8));
 
 					tx->gl_texturenum = GL_LoadTexture4(mt->name, w, h, (byte*)(f + 16), GU_LINEAR, qfalse);
-					mapTextureNameList.push_back(tx->gl_texturenum);
 				}
 	
 			}
@@ -625,7 +602,6 @@ void Mod_LoadTextures (lump_t *l)
 			{
 				tx->gl_texturenum = GL_LoadTexture (mt->name, tx->width, tx->height, (byte *)(tx_pixels), qtrue, GU_LINEAR, level);
 			}
-			mapTextureNameList.push_back(tx->gl_texturenum);
 /*
 		          //Crow_bar mult detail textures
 				  sprintf (detname, "gfx/detail/%s", mt->name);
@@ -645,7 +621,6 @@ void Mod_LoadTextures (lump_t *l)
 				// load the fullbright pixels version of the texture
 				tx->fullbright =
 			        GL_LoadTexture (fbr_mask_name, tx->width, tx->height, (byte *)(tx_pixels), qtrue, GU_LINEAR, level);
-				mapTextureNameList.push_back(tx->fullbright);
 			}
 			else
 				tx->fullbright = -1; // because 0 is a potentially valid texture number
@@ -2112,7 +2087,6 @@ void *Mod_LoadAllSkins (int numskins, daliasskintype_t *pskintype)
 
 	if (model_is_zombie(loadmodel->name) == qtrue) {
 		Mod_FloodFillSkin(skin, pheader->skinwidth, pheader->skinheight);
-
 		// force-fill 4 skin slots
 		for (int i = 0; i < 4; i++) {
 			switch(i) {
@@ -2172,14 +2146,12 @@ void *Mod_LoadAllSkins (int numskins, daliasskintype_t *pskintype)
 					pheader->gl_texturenum[i][2] =
 					pheader->gl_texturenum[i][3] = loadtextureimage("models/machines/v_perk.mdl_0", 0, 0, qtrue, GU_LINEAR);
 					pskintype = (daliasskintype_t *)((byte *)(pskintype+1) + s);
-					mapTextureNameList.push_back(pheader->gl_texturenum[i][i]); 
 				} else if (!has_perk_revive && i == 0) {
 					pheader->gl_texturenum[i][0] =
 					pheader->gl_texturenum[i][1] =
 					pheader->gl_texturenum[i][2] =
 					pheader->gl_texturenum[i][3] = zombie_skins[0][0];
 					pskintype = (daliasskintype_t *)((byte *)(pskintype+1) + s);
-					mapTextureNameList.push_back(pheader->gl_texturenum[i][i]); 
 				}
 				if (i == 1 && has_perk_juggernog) {
 					pheader->gl_texturenum[i][0] =
@@ -2187,14 +2159,12 @@ void *Mod_LoadAllSkins (int numskins, daliasskintype_t *pskintype)
 					pheader->gl_texturenum[i][2] =
 					pheader->gl_texturenum[i][3] = loadtextureimage("models/machines/v_perk.mdl_1", 0, 0, qtrue, GU_LINEAR);
 					pskintype = (daliasskintype_t *)((byte *)(pskintype+1) + s);
-					mapTextureNameList.push_back(pheader->gl_texturenum[i][i]); 
 				} else if (!has_perk_juggernog && i == 1) {
 					pheader->gl_texturenum[i][0] =
 					pheader->gl_texturenum[i][1] =
 					pheader->gl_texturenum[i][2] =
 					pheader->gl_texturenum[i][3] = zombie_skins[0][0];
 					pskintype = (daliasskintype_t *)((byte *)(pskintype+1) + s);
-					mapTextureNameList.push_back(pheader->gl_texturenum[i][i]); 
 				}
 				if (i == 2 && has_perk_speedcola) {
 					pheader->gl_texturenum[i][0] =
@@ -2202,14 +2172,12 @@ void *Mod_LoadAllSkins (int numskins, daliasskintype_t *pskintype)
 					pheader->gl_texturenum[i][2] =
 					pheader->gl_texturenum[i][3] = loadtextureimage("models/machines/v_perk.mdl_2", 0, 0, qtrue, GU_LINEAR);
 					pskintype = (daliasskintype_t *)((byte *)(pskintype+1) + s);
-					mapTextureNameList.push_back(pheader->gl_texturenum[i][i]); 
 				} else if (!has_perk_speedcola && i == 2) {
 					pheader->gl_texturenum[i][0] =
 					pheader->gl_texturenum[i][1] =
 					pheader->gl_texturenum[i][2] =
 					pheader->gl_texturenum[i][3] = zombie_skins[0][0];
 					pskintype = (daliasskintype_t *)((byte *)(pskintype+1) + s);
-					mapTextureNameList.push_back(pheader->gl_texturenum[i][i]); 
 				}
 				if (i == 3 && has_perk_doubletap) {
 					pheader->gl_texturenum[i][0] =
@@ -2217,14 +2185,12 @@ void *Mod_LoadAllSkins (int numskins, daliasskintype_t *pskintype)
 					pheader->gl_texturenum[i][2] =
 					pheader->gl_texturenum[i][3] = loadtextureimage("models/machines/v_perk.mdl_3", 0, 0, qtrue, GU_LINEAR);
 					pskintype = (daliasskintype_t *)((byte *)(pskintype+1) + s);
-					mapTextureNameList.push_back(pheader->gl_texturenum[i][i]); 
 				} else if (!has_perk_doubletap && i == 3) {
 					pheader->gl_texturenum[i][0] =
 					pheader->gl_texturenum[i][1] =
 					pheader->gl_texturenum[i][2] =
 					pheader->gl_texturenum[i][3] = zombie_skins[0][0];
 					pskintype = (daliasskintype_t *)((byte *)(pskintype+1) + s);
-					mapTextureNameList.push_back(pheader->gl_texturenum[i][i]); 
 				}
 				if (i == 4 && has_perk_staminup) {
 					pheader->gl_texturenum[i][0] =
@@ -2232,14 +2198,12 @@ void *Mod_LoadAllSkins (int numskins, daliasskintype_t *pskintype)
 					pheader->gl_texturenum[i][2] =
 					pheader->gl_texturenum[i][3] = loadtextureimage("models/machines/v_perk.mdl_4", 0, 0, qtrue, GU_LINEAR);
 					pskintype = (daliasskintype_t *)((byte *)(pskintype+1) + s);
-					mapTextureNameList.push_back(pheader->gl_texturenum[i][i]); 
 				} else if (!has_perk_staminup && i == 4) {
 					pheader->gl_texturenum[i][0] =
 					pheader->gl_texturenum[i][1] =
 					pheader->gl_texturenum[i][2] =
 					pheader->gl_texturenum[i][3] = zombie_skins[0][0];
 					pskintype = (daliasskintype_t *)((byte *)(pskintype+1) + s);
-					mapTextureNameList.push_back(pheader->gl_texturenum[i][i]); 
 				}
 				if (i == 5 && has_perk_flopper) {
 					pheader->gl_texturenum[i][0] =
@@ -2247,14 +2211,12 @@ void *Mod_LoadAllSkins (int numskins, daliasskintype_t *pskintype)
 					pheader->gl_texturenum[i][2] =
 					pheader->gl_texturenum[i][3] = loadtextureimage("models/machines/v_perk.mdl_5", 0, 0, qtrue, GU_LINEAR);
 					pskintype = (daliasskintype_t *)((byte *)(pskintype+1) + s);
-					mapTextureNameList.push_back(pheader->gl_texturenum[i][i]); 
 				} else if (!has_perk_flopper && i == 5) {
 					pheader->gl_texturenum[i][0] =
 					pheader->gl_texturenum[i][1] =
 					pheader->gl_texturenum[i][2] =
 					pheader->gl_texturenum[i][3] = zombie_skins[0][0];
 					pskintype = (daliasskintype_t *)((byte *)(pskintype+1) + s);
-					mapTextureNameList.push_back(pheader->gl_texturenum[i][i]); 
 				}
 				if (i == 6 && has_perk_deadshot) {
 					pheader->gl_texturenum[i][0] =
@@ -2262,14 +2224,12 @@ void *Mod_LoadAllSkins (int numskins, daliasskintype_t *pskintype)
 					pheader->gl_texturenum[i][2] =
 					pheader->gl_texturenum[i][3] = loadtextureimage("models/machines/v_perk.mdl_6", 0, 0, qtrue, GU_LINEAR);
 					pskintype = (daliasskintype_t *)((byte *)(pskintype+1) + s);
-					mapTextureNameList.push_back(pheader->gl_texturenum[i][i]); 
 				} else if (!has_perk_deadshot && i == 6) {
 					pheader->gl_texturenum[i][0] =
 					pheader->gl_texturenum[i][1] =
 					pheader->gl_texturenum[i][2] =
 					pheader->gl_texturenum[i][3] = zombie_skins[0][0];
 					pskintype = (daliasskintype_t *)((byte *)(pskintype+1) + s);
-					mapTextureNameList.push_back(pheader->gl_texturenum[i][i]); 
 				}
 				if (i == 7 && has_perk_mulekick) {
 					pheader->gl_texturenum[i][0] =
@@ -2277,14 +2237,12 @@ void *Mod_LoadAllSkins (int numskins, daliasskintype_t *pskintype)
 					pheader->gl_texturenum[i][2] =
 					pheader->gl_texturenum[i][3] = loadtextureimage("models/machines/v_perk.mdl_7", 0, 0, qtrue, GU_LINEAR);
 					pskintype = (daliasskintype_t *)((byte *)(pskintype+1) + s);
-					mapTextureNameList.push_back(pheader->gl_texturenum[i][i]); 
 				} else if (!has_perk_mulekick && i == 7) {
 					pheader->gl_texturenum[i][0] =
 					pheader->gl_texturenum[i][1] =
 					pheader->gl_texturenum[i][2] =
 					pheader->gl_texturenum[i][3] = zombie_skins[0][0];
 					pskintype = (daliasskintype_t *)((byte *)(pskintype+1) + s);
-					mapTextureNameList.push_back(pheader->gl_texturenum[i][i]); 
 				}
 			}
 
@@ -2339,9 +2297,6 @@ void *Mod_LoadAllSkins (int numskins, daliasskintype_t *pskintype)
 				pheader->gl_texturenum[i][3] = loadrgbafrompal(name, pheader->skinwidth, pheader->skinheight, (byte*)(pskintype+1));
 			}
 			pskintype = (daliasskintype_t *)((byte *)(pskintype+1) + s);
-			/* Crow_bar Memory Leak Fixed   One Work not used       */
-			mapTextureNameList.push_back(pheader->gl_texturenum[i][i]);
-			/* Crow_bar Memory Leak Fixed                           */
 		}
 		else
 		{
@@ -2376,9 +2331,6 @@ void *Mod_LoadAllSkins (int numskins, daliasskintype_t *pskintype)
 					}
 				}
 				pskintype = (daliasskintype_t *)((byte *)(pskintype) + s);
-				/* Crow_bar Memory Leak Fixed*/
-				mapTextureNameList.push_back(pheader->gl_texturenum[i][j&3]);
-				/* Crow_bar Memory Leak Fixed*/
 			}
 			k = j;
 			for (/* */; j < 4; j++)
@@ -2824,9 +2776,6 @@ void Mod_LoadQ2AliasModel (model_t *mod, void *buffer)
 		{
 			pheader->gl_texturenum[i] = loadtextureimage (pinskins, 0, 0, qtrue, GU_LINEAR);
 			pinskins += MD2MAX_SKINNAME;
-            /* Crow_bar Memory Leak Fixed                           */
-			mapTextureNameList.push_back(pheader->gl_texturenum[i]);
-            /* Crow_bar Memory Leak Fixed                           */
 		}
 	}
 
@@ -3091,8 +3040,6 @@ void Mod_LoadQ3ModelTexture (char *identifier, int flags, int *gl_texnum)
 		Q_snprintfz (loadpath, sizeof(loadpath), "maps/%s", identifier);
 		*gl_texnum = loadtextureimage (loadpath, 0, 0, qtrue, GU_LINEAR);
 	}
-
-	mapTextureNameList.push_back(*gl_texnum);
 }
 
 //==============================================================================
@@ -3653,10 +3600,6 @@ void * Mod_LoadSpriteFrame (void * pin, mspriteframe_t **ppframe, int framenum, 
 		Sys_Error("Mod_LoadSpriteFrame: Non sprite type");
 	}
 
-	/* Crow_bar Memory Leak Fixed                           */
-	mapTextureNameList.push_back(pspriteframe->gl_texturenum);
-	/* Crow_bar Memory Leak Fixed                           */
-
 	return (void *)((byte *)pinframe + sizeof (dspriteframe_t) + size);
 }
 
@@ -3973,7 +3916,6 @@ qboolean Mod_LoadQ2SpriteModel (model_t *mod, void *buffer)
 		frame = psprite->frames[i].frameptr = static_cast<mspriteframe_t*>(Hunk_AllocName(sizeof(mspriteframe_t), loadname));
 
 		frame->gl_texturenum = loadtextureimage (pframetype->name, 0, 0, qtrue, GU_LINEAR);
-        mapTextureNameList.push_back(frame->gl_texturenum);
 
 		frame->width = LittleLong(pframetype->width);
 		frame->height = LittleLong(pframetype->height);

--- a/source/psp/video_hardware_screen.cpp
+++ b/source/psp/video_hardware_screen.cpp
@@ -111,7 +111,8 @@ qpic_t      *hitmark;
 /*qpic_t 		*ls_ndu;
 qpic_t 		*ls_warehouse;
 qpic_t      *ls_xmas;*/
-qpic_t 		*lscreen;
+// qpic_t 		*lscreen;
+int lscreen_index;
 
 int			scr_fullupdate;
 
@@ -862,7 +863,7 @@ char *lodinglinetext;
 qpic_t *awoo;
 char *ReturnLoadingtex (void)
 {
-    int StringNum = Random_Int(55);
+    int StringNum = Random_Int(61);
     switch(StringNum)
     {
         case 1:
@@ -1027,10 +1028,31 @@ char *ReturnLoadingtex (void)
 		case 54:
 			return  "Play some Custom Maps!";
 			break;
+		case 55:
+			return  "Real OGs play on a PSP-1000!";
+			break;
+		case 56:
+			return  "Adding this tip improved framerate by 39%!";
+			break;
+		case 57:
+			return  "The NZ in NZP stands for New Zealand!";
+			break;
+		case 58:
+			return  "The P in NZP stands for Professional!";
+			break;
+		case 59:
+			return  "Many people have worked on this game!";
+			break;
+		case 60:
+			return  "Remember to stay hydrated!";
+			break;
+		case 61:
+			return  "cofe";
+			break;
     }
     return "wut wut";
 }
-qboolean load_screen_exists;
+
 void SCR_DrawLoadScreen (void)
 {
 
@@ -1041,24 +1063,16 @@ void SCR_DrawLoadScreen (void)
 
 	if (loadingScreen) {
 		if (!loadscreeninit) {
-			load_screen_exists = qfalse;
-
-			char* lpath;
-			lpath = (char*)Z_Malloc(sizeof(char)*32);
+			char lpath[32];
 			strcpy(lpath, "gfx/lscreen/");
 			strcat(lpath, loadname2);
-
-			lscreen = Draw_CachePic(lpath);
+			lscreen_index = loadtextureimage(lpath, 0, 0, qfalse, GU_LINEAR);
 			awoo = Draw_CacheImg("gfx/menu/awoo");
-
-			if (lscreen != NULL)
-				load_screen_exists = qtrue;
-
 			loadscreeninit = qtrue;
 		}
 
-		if (load_screen_exists == qtrue)
-			Draw_Pic(scr_vrect.x, scr_vrect.y, lscreen);
+		if (lscreen_index > 0)
+			Draw_PicIndex(scr_vrect.x, scr_vrect.y, 480, 272, lscreen_index);
 
 		Draw_FillByColor(0, 0, 480, 24, GU_RGBA(0, 0, 0, 150));
 		Draw_FillByColor(0, 248, 480, 24, GU_RGBA(0, 0, 0, 150));

--- a/source/render.h
+++ b/source/render.h
@@ -179,8 +179,6 @@ typedef struct
 //
 // refresh
 //
-extern	int		reinit_surfcache;
-
 
 extern	refdef_t	r_refdef;
 extern vec3_t	r_origin, vpn, vright, vup;
@@ -226,16 +224,6 @@ void R_TeleportSplash (vec3_t org);
 
 void R_PushDlights (void);
 
-
-//
-// surface cache related
-//
-extern	int		reinit_surfcache;	// if 1, surface cache is currently empty and
-extern qboolean	r_cache_thrash;	// set if thrashing the surface cache
-
-int	D_SurfaceCacheForRes (int width, int height);
-void D_FlushCaches (void);
-void D_DeleteSurfaceCache (void);
 void D_InitCaches (void *buffer, int size);
 void R_SetVrect (vrect_t *pvrect, vrect_t *pvrectin, int lineadj);
 


### PR DESCRIPTION
Changed texture management to not use the c++ list, but hook it with gltextures. Properly clear all non-permanent gltextures on every reload. This also allowed us to not keep the menu pics in memory when actually playing.
Fixed at least one memory leak as well. Memory use seems kind of stable when reloading maps a few times.