### PR TITLE
Add horizon fog blending for sky

### DIFF
--- a/source/console.c
+++ b/source/console.c
@@ -62,6 +62,9 @@ qboolean	con_initialized;
 
 int			con_notifylines;		// scan lines to clear for notify lines
 
+#define MAXGAMEDIRLEN	1000
+char debuglogfile[MAXGAMEDIRLEN + 1];
+
 extern void M_Menu_Main_f (void);
 
 void M_OSK_Draw (void);
@@ -218,8 +221,6 @@ Con_Init
 */
 void Con_Init (void)
 {
-#define MAXGAMEDIRLEN	1000
-	char	temp[MAXGAMEDIRLEN+1];
 	char	*t2 = "/condebug.log";
 
 	con_debuglog = COM_CheckParm("-condebug");
@@ -228,8 +229,8 @@ void Con_Init (void)
 	{
 		if (strlen (com_gamedir) < (MAXGAMEDIRLEN - strlen (t2)))
 		{
-			sprintf (temp, "%s%s", com_gamedir, t2);
-			unlink (temp);
+			sprintf (debuglogfile, "%s%s", com_gamedir, t2);
+			unlink (debuglogfile);
 		}
 	}
 
@@ -396,7 +397,7 @@ void Con_Printf (char *fmt, ...)
 
 // log all messages to file
 	if (con_debuglog)
-		Con_DebugLog(va("%s/condebug.log",com_gamedir), "%s", msg);
+		Con_DebugLog(debuglogfile, "%s", msg);
 
 	if (!con_initialized)
 		return;

--- a/source/psp/video_hardware.h
+++ b/source/psp/video_hardware.h
@@ -36,6 +36,7 @@ int GL_LoadTextureLM (const char *identifier, int width, int height, const byte 
 int GL_LoadImages (const char *identifier, int width, int height, const byte *data, qboolean stretch_to_power_of_two, int filter, int mipmap_level, int bpp);
 int GL_LoadTexturePixels (byte *data, char *identifier, int width, int height, int mode);
 int loadtextureimage (char* filename, int matchwidth, int matchheight, qboolean complain, int filter);
+int loadskyboxsideimage (char* filename, int matchwidth, int matchheight, qboolean complain, int filter);
 int GL_LoadPaletteTexture (const char *identifier, int width, int height, const byte *data, byte *palette, int paltype, qboolean stretch_to_power_of_two, int filter, int mipmap_level);
 
 //Crow_bar
@@ -195,7 +196,7 @@ extern	mleaf_t		*r_viewleaf, *r_oldviewleaf;
 extern	texture_t	*r_notexture_mip;
 extern	int		d_lightstylevalue[256];	// 8.8 fraction of base light value
 
-extern  int	    skyimage[6]; // Where sky images are stored
+extern  int	    skyimage[5]; // Where sky images are stored
 extern  int 	lightmap_index[MAX_LIGHTMAPS]; // Where lightmaps are stored
 
 extern  int     reloaded_pallete;
@@ -239,6 +240,7 @@ extern  cvar_t  r_asynch;
 extern  cvar_t  cl_loadmapcfg;
 extern  cvar_t  r_fastsky;
 extern  cvar_t  r_skycolor;
+extern  cvar_t  r_skyfogblend;
 extern	cvar_t	r_waterripple;
 extern	cvar_t	r_norefresh;
 extern	cvar_t	r_drawentities;
@@ -422,6 +424,7 @@ int 	      D_DrawParticleBuffered (psp_particle* vertices, particle2_t *pparticl
 
 
 extern int			zombie_skins[2][2];
+extern qpic_t*		sniper_scope;
 
 extern int faces_rejected, faces_checked, faces_clipped;
 

--- a/source/psp/video_hardware_QMB.cpp
+++ b/source/psp/video_hardware_QMB.cpp
@@ -64,7 +64,6 @@ typedef	enum
 	p_blood2,
 	p_blood3,
 	p_bloodcloud,
-    p_q3blood,
 	p_flame,
 	p_lavatrail,
 	p_bubble2,
@@ -86,15 +85,7 @@ typedef	enum
 	p_muzzleflash3,
 
 #endif // SLIM
-
-    p_q3blood_trail,
-	p_q3blood_decal,
-	p_q3rocketsmoke,
-	p_q3grenadesmoke,
-	p_q3explosion,
 	p_q3flame,
-	p_q3gunshot,
-	p_q3teleport,
 	num_particletypes
 } part_type_t;
 
@@ -132,10 +123,6 @@ typedef	enum
 #endif // SLIM
 
 	ptex_bloodcloud,
-   	ptex_q3blood,
-	ptex_q3blood_trail,
-	ptex_q3smoke,
-	ptex_q3explosion,
 	ptex_q3flame,
 	num_particletextures
 } part_tex_t;
@@ -268,15 +255,7 @@ static byte *ColorForParticle (part_type_t type)
 		color[3] = 64;
 		break;
 
-	case p_q3rocketsmoke:
-	case p_q3grenadesmoke:
-		color[0] = color[1] = color[2] = 160;
-		break;
-
-	case p_q3explosion:
 	case p_q3flame:
-	case p_q3gunshot:	// not used
-	case p_q3teleport:	// not used
 		color[0] = color[1] = color[2] = 255;
 		break;
 
@@ -352,13 +331,6 @@ static byte *ColorForParticle (part_type_t type)
 		color[0] = (50 + (rand() & 31));
 		color[1] = color[2] = 0;
 		color[3] = 200;
-		break;
-
-	case p_q3blood:
-	case p_q3blood_trail:
-	case p_q3blood_decal:
-		color[0] = 180;
-		color[1] = color[2] = 0;
 		break;
 
 	case p_flame:
@@ -471,32 +443,6 @@ void QMB_InitParticles (void)
 
 	loading_cur_step++;
 	SCR_UpdateScreen ();
-
-	// load the rest of the images
-	if(!(particleimage = loadtextureimage("textures/particles/q3particlefont", 0, 0, qfalse, GU_LINEAR)))
-	{
-		//Clear_LoadingFill ();
-		return;
-	}
-
-	GL_MarkTextureAsPermanent(particleimage);
-	
-	max_s = 384.0; max_t = 192.0;
-	for (i = 0, ti = 0 ; i < 2 ; i++)
-		for (j = 0 ; j < 4 ; j++, ti++)
-			ADD_PARTICLE_TEXTURE(ptex_q3explosion, particleimage, ti, 8, j * 64, i * 64, (j + 1) * 64, (i + 1) * 64);
-		
-	
-	loading_cur_step++;
-	SCR_UpdateScreen ();
-
-	for (i = 0 ; i < 5 ; i++)
-		ADD_PARTICLE_TEXTURE(ptex_q3blood, particleimage, i, 5, i * 64, 128, (i + 1) * 64, 192);
-		ADD_PARTICLE_TEXTURE(ptex_q3smoke, particleimage, 0, 1, 256, 0, 384, 128);
-		ADD_PARTICLE_TEXTURE(ptex_q3blood_trail, particleimage, 0, 1, 320, 128, 384, 192);
-	
-	loading_cur_step++;
-	SCR_UpdateScreen ();
 	
 	max_s = max_t = 128.0;
 
@@ -507,13 +453,9 @@ void QMB_InitParticles (void)
 	}
 
 	GL_MarkTextureAsPermanent(particleimage);
-	
-	/*max_s = max_t = 128.0;
-	for (i = 0, ti = 0 ; i < 2 ; i++)
-		for (j = 0 ; j < 2 ; j++, ti++)
-			ADD_PARTICLE_TEXTURE(ptex_q3flame, particleimage, ti, 8, j * 64, i * 64, (j + 1) * 64, (i + 1) * 64);*/
-	max_s = max_t = 64.0;
 	ADD_PARTICLE_TEXTURE(ptex_q3flame, particleimage, 0, 1, 0, 0, 64, 64);
+	
+	max_s = max_t = 64.0;
     loading_cur_step++;
 	SCR_UpdateScreen ();
 
@@ -690,19 +632,10 @@ void QMB_InitParticles (void)
 	
 	//shpuldeditedthis(GI_ONE_MINUS_DST_ALPHA->GL_ONE_MINUS_SRC_ALPHA) (edited one right after this comment)
 	ADD_PARTICLE_TYPE(p_bloodcloud, pd_billboard, GU_SRC_ALPHA, GU_ONE_MINUS_SRC_ALPHA, ptex_bloodcloud, 255, -2, 0, pm_normal, 0);
-	ADD_PARTICLE_TYPE(p_q3blood, pd_billboard, GU_SRC_ALPHA, GU_ONE_MINUS_SRC_ALPHA, ptex_q3blood, 255, 0, 0, pm_static, -1);
-	ADD_PARTICLE_TYPE(p_q3blood_trail, pd_billboard, GU_SRC_ALPHA, GU_ONE_MINUS_SRC_ALPHA, ptex_q3blood_trail, 255, -1.5, 0, pm_die, -1);
-	ADD_PARTICLE_TYPE(p_q3rocketsmoke, pd_billboard, GU_SRC_ALPHA, GU_ONE_MINUS_SRC_ALPHA, ptex_q3smoke, 80, 0, 0, pm_die, 0);
-	
 	loading_cur_step++;
 	SCR_UpdateScreen();
 	
-	ADD_PARTICLE_TYPE(p_q3grenadesmoke, pd_billboard, GU_SRC_ALPHA, GU_ONE_MINUS_SRC_ALPHA, ptex_q3smoke, 80, 0, 0, pm_die, 0);
-	ADD_PARTICLE_TYPE(p_q3explosion, pd_billboard, GU_SRC_ALPHA, GU_ONE_MINUS_DST_ALPHA, ptex_q3explosion, 204, 0, 0, pm_static, -1);
-	//old: ADD_PARTICLE_TYPE(p_q3flame, pd_q3flame, GU_SRC_ALPHA, GU_ONE_MINUS_DST_ALPHA, ptex_q3flame, 204, 0, 0, pm_static, -1);
 	ADD_PARTICLE_TYPE(p_q3flame, pd_billboard, GU_SRC_ALPHA, GU_FIX, ptex_q3flame, 180, 0.66, 0, pm_nophysics, 0);
-	ADD_PARTICLE_TYPE(p_q3gunshot, pd_q3gunshot, GU_SRC_ALPHA, GU_ONE_MINUS_DST_ALPHA, ptex_none, 255, 0, 0, pm_static, -1);
-	ADD_PARTICLE_TYPE(p_q3teleport, pd_q3teleport, GU_SRC_ALPHA, GU_ONE_MINUS_DST_ALPHA, ptex_none, 255, 0, 0, pm_static, -1);
 
 	loading_cur_step++;
 	strcpy(loading_name, "particles");
@@ -817,7 +750,6 @@ __inline static void AddParticle (part_type_t type, vec3_t org, int count, float
 		case p_streak:
 		case p_streakwave:
 		case p_shockwave:
-		case p_q3teleport:
 			VectorCopy (org, p->org);
 			VectorCopy (dir, p->vel);
 			break;
@@ -857,24 +789,6 @@ __inline static void AddParticle (part_type_t type, vec3_t org, int count, float
 			VectorClear (p->vel);
 			p->growth = -30;
 			break;
-
-		case p_q3explosion:
-				p->texindex = 0;
-				VectorCopy (org, p->org);
-				VectorClear (p->vel);
-				p->growth = 50;
-				for (j=1 ; j<8 ; j++)
-				{
-					INIT_NEW_PARTICLE(pt, p, color, size, time);
-					p->size = size + j * 2;
-					p->start = cl.time + (j * time / 2.0);
-					p->die = p->start + time;
-					p->texindex = j;
-					VectorCopy (org, p->org);
-					VectorClear (p->vel);
-					p->growth = 50;
-				}
-				break;
 
 		case p_sparkray:
 			VectorCopy (org, p->endorg);
@@ -942,23 +856,6 @@ __inline static void AddParticle (part_type_t type, vec3_t org, int count, float
 				p->vel[j] = (rand() % 40) - 20;
 			break;
 
-		case p_q3blood:
-			p->texindex = q3blood_texindex++ % 5;
-			for (k=0 ; k<3 ; k++)
-				p->org[k] = org[k] + (rand() & 15) - 8;
-			VectorClear (p->vel);
-			for (j=1 ; j<3 ; j++)
-			{
-				INIT_NEW_PARTICLE(pt, p, color, size, time);
-				p->start = cl.time + (j * time);
-				p->die = p->start + time;
-				p->texindex = q3blood_texindex++ % 5;
-				for (k=0 ; k<3 ; k++)
-					p->org[k] = org[k] + (rand() & 15) - 8;
-				VectorClear (p->vel);
-			}
-			break;
-
 		case p_flame:
 			VectorCopy (org, p->org);
 			p->growth = -p->size / 2;
@@ -973,19 +870,6 @@ __inline static void AddParticle (part_type_t type, vec3_t org, int count, float
 			p->vel[1] = (rand() & 3) - 2;
 			p->vel[2] = (rand() & 2);
 			p->growth = 6;
-			break;
-
-		case p_q3gunshot:
-			p->texindex = 0;	// used for animation here
-			VectorCopy (org, p->org);
-			for (j=1 ; j<3 ; j++)
-			{
-				INIT_NEW_PARTICLE(pt, p, color, size, time);
-				p->start = cl.time + (j * time / 2.0);
-				p->die = p->start + time;
-				p->texindex = j + 1;
-				VectorCopy (org, p->org);
-			}
 			break;
 
 		case p_torch_flame:
@@ -1048,16 +932,6 @@ __inline static void AddParticleTrail (part_type_t type, vec3_t start, vec3_t en
 
 	switch (type)
 	{
-
-    case p_q3blood_trail:
-	case p_q3rocketsmoke:
-		count = length / 40.0;
-		break;
-
-	case p_q3grenadesmoke:
-		count = length / 12.0;
-		break;
-
 	case p_alphatrail:
 	case p_trailpart:
 	case p_lavatrail:
@@ -1119,15 +993,6 @@ __inline static void AddParticleTrail (part_type_t type, vec3_t start, vec3_t en
 			p->growth = 6;
 			break;
 
-		case p_q3blood_trail:
-			VectorCopy (point, p->org);
-			for (j=0 ; j<3 ; j++)
-				p->org[j] += ((rand() & 15) - 8) / 8.0;
-			for (j=0 ; j<3 ; j++)
-				p->vel[j] = ((rand() & 15) - 8) / 2.0;
-			p->growth = 6;
-			break;
-
 		case p_bubble2:
 			VectorCopy(point, p->org);
 			for (j=0 ; j<3 ; j++)
@@ -1156,19 +1021,6 @@ __inline static void AddParticleTrail (part_type_t type, vec3_t start, vec3_t en
 			p->vel[2] = rand() & 3;
 			p->growth = 4.5;
 			p->rotspeed = (rand() & 63) + 96;
-			break;
-
-        case p_q3rocketsmoke:
-		case p_q3grenadesmoke:
-			VectorCopy (point, p->org);
-			for (j=0 ; j<3 ; j++)
-				p->org[j] += ((rand() & 7) - 4) / 8.0;
-			VectorClear (p->vel);
-			p->growth = 30;
-			if (rotangle >= 360)
-				rotangle = 0;
-			p->rotangle = rotangle;
-			rotangle += 30;
 			break;
 
 		case p_dpsmoke:
@@ -1290,25 +1142,6 @@ inline static void QMB_UpdateParticles(void)
 
 			switch (pt->id)
 			{
-
-			case p_q3blood:	// avoid alpha for q3blood
-				p->color[3] = 255;
-				break;
-
-			case p_q3explosion:
-			case p_q3gunshot:
-				if (particle_time < (p->start + (p->die - p->start) / 2.0))
-				{
-					if (pt->id == p_q3gunshot && !p->texindex)
-						p->color[3] = 255;
-					else
-						p->color[3] = pt->startalpha * ((particle_time - p->start) / (p->die - p->start) * 2);
-				}
-				else
-				{
-					p->color[3] = pt->startalpha * ((p->die - particle_time) / (p->die - p->start) * 2);
-				}
-				break;
 			case p_streaktrail://R00k
 			case p_lightningbeam:
 					p->color[3] = p->bounces * ((p->die - particle_time) / (p->die - p->start));
@@ -1415,8 +1248,6 @@ inline static void QMB_UpdateParticles(void)
 							  R_SpawnDecal (p->org, normal, tangent, decal_blood1, 12, 0);
 						    else if (pt->id == p_blood2 && r_decal_blood.value)
 							  R_SpawnDecal (p->org, normal, tangent, decal_blood2, 12, 0);
-						    else if (pt->id == p_q3blood_trail && r_decal_blood.value)
-							  R_SpawnDecal (p->org, normal, tangent, decal_q3blood, 48, 0);
 
 						}
 					}
@@ -1546,7 +1377,7 @@ void R_CalcBeamVerts (float *vert, vec3_t org1, vec3_t org2, float width)
 }
 
 #define DRAW_PARTICLE_BILLBOARD(_ptex, _p, _coord)		\
-	sceGumPushMatrix ();									\
+	sceGumPushMatrix ();								\
 														\
     const ScePspFVector3 translation =                  \
     {                                                   \
@@ -1560,7 +1391,7 @@ void R_CalcBeamVerts (float *vert, vec3_t org1, vec3_t org2, float width)
 	};                                                  \
 	sceGumScale(&scale);			                    \
 														\
-	if (_p->rotspeed || pt->id == p_q3rocketsmoke || pt->id == p_q3grenadesmoke)\
+	if (_p->rotspeed)									\
 	{                                                   \
 		const ScePspFVector3 rotation =                 \
 	    {                                               \
@@ -2049,25 +1880,11 @@ void QMB_ParticleExplosion (vec3_t org)
 		AddParticle (p_bubble, org, 6, 3.0, 2.5, NULL, zerodir);
 		AddParticle (p_bubble, org, 4, 2.35, 2.5, NULL, zerodir);
 
-		if (r_part_explosions.value == 2)
+		AddParticle (p_fire, org, 16, 120, 1, NULL, zerodir);
+		if (r_explosiontype.value != 1)
 		{
-			AddParticle (p_q3explosion, org, 1, 36, 0.2, NULL, zerodir);
-		}
-		else
-		{
-			if (r_part_explosions.value == 2)
-		    {
-			AddParticle (p_q3explosion, org, 1, 36, 0.2, NULL, zerodir);
-		    }
-		    else
-		    {
-			   AddParticle (p_fire, org, 16, 120, 1, NULL, zerodir);
-			   if (r_explosiontype.value != 1)
-			   {
-				 AddParticle (p_spark, org, 50, 250, 0.925f, NULL, zerodir);
-				 AddParticle (p_spark, org, 25, 150, 0.925f, NULL, zerodir);
-			   }
-		    }
+			AddParticle (p_spark, org, 50, 250, 0.925f, NULL, zerodir);
+			AddParticle (p_spark, org, 25, 150, 0.925f, NULL, zerodir);
 		}
 	}
 	else
@@ -2316,10 +2133,7 @@ void QMB_RunParticleEffect (vec3_t org, vec3_t dir, int col, int count)
 		{
 			color[0] = 200;	color[1] = 200;	color[2] = 125;
 
-			if (r_part_spikes.value == 2)
-				AddParticle (p_q3gunshot, org, 1, 1, 0.3, NULL, zerodir);
-			else
-				AddParticle (p_spark, org, 6, 70, 0.6, NULL, zerodir);
+			AddParticle (p_spark, org, 6, 70, 0.6, NULL, zerodir);
 
 			AddParticle (p_chunk, org, 3, 1, 0.75, NULL, zerodir);
 
@@ -2340,11 +2154,7 @@ void QMB_RunParticleEffect (vec3_t org, vec3_t dir, int col, int count)
 	case 20://super nailgun
 		color[0] = 200;	color[1] = 200;	color[2] = 125;
 
-		if (r_part_spikes.value == 2)
-			AddParticle (p_q3gunshot, org, 1, 1, 0.3, NULL, zerodir);
-		else
-		    //AddParticle (p_spark, org, 2, 85, 0.4, color, zerodir);
-            AddParticle (p_spark, org, 22, 100, 0.2, NULL, zerodir);
+        AddParticle (p_spark, org, 22, 100, 0.2, NULL, zerodir);
 
 		//AddParticle (p_chunk, org, 6, 2, 0.75, NULL, zerodir);
 
@@ -2362,12 +2172,6 @@ void QMB_RunParticleEffect (vec3_t org, vec3_t dir, int col, int count)
 		break;
 
 	case 24:// gunshot
-      if (r_part_gunshots.value == 2)
-	  {
-		AddParticle (p_q3gunshot, org, 1, 1, 0.3, NULL, zerodir);
-	  }
-	  else
-	  {
 		particlecount = count >> 1;
 		AddParticle (p_gunblast, org, 1, 1.04, 0.2, NULL, zerodir);
 		for (i=0 ; i<particlecount ; i++)
@@ -2392,19 +2196,11 @@ void QMB_RunParticleEffect (vec3_t org, vec3_t dir, int col, int count)
 			}
 
 		}
-	  }
 		break;
 
 	case 30:
-		if (r_part_spikes.value == 2)
-		{
-			AddParticle (p_q3gunshot, org, 1, 1, 0.3, NULL, zerodir);
-		}
-		else
-		{
-			AddParticle (p_chunk, org, 10, 1, 4, NULL, zerodir);
-			AddParticle (p_spark, org, 8, 105, 0.9, NULL, zerodir);
-		}
+		AddParticle (p_chunk, org, 10, 1, 4, NULL, zerodir);
+		AddParticle (p_spark, org, 8, 105, 0.9, NULL, zerodir);
 		break;
 
 	case 128:	// electric sparks (R00k added from QMB)
@@ -2756,10 +2552,7 @@ void QMB_RocketTrail (vec3_t start, vec3_t end, trail_type_t type)
 
 	case BLOOD_TRAIL:
 	case SLIGHT_BLOOD_TRAIL:
-		if (r_part_trails.value == 2)
-			AddParticleTrail (p_q3blood_trail, start, end, 15, 2, NULL);
-		else
-			AddParticleTrail (p_blood3, start, end, type == BLOOD_TRAIL ? 1.35 : 2.4, 2, NULL);
+		AddParticleTrail (p_blood3, start, end, type == BLOOD_TRAIL ? 1.35 : 2.4, 2, NULL);
 		break;
 
 	case TRACER1_TRAIL:
@@ -2978,12 +2771,6 @@ void QMB_TeleportSplash (vec3_t org)
 	int		i, j, k;
 	vec3_t		neworg, angle;
 	col_t		color;
-
-	if (r_part_telesplash.value == 2)
-	{
-		AddParticle (p_q3teleport, org, 1, 1, 1.0, NULL, zerodir);
-		return;
-	}
 
 	//QMB_Shockwave_Splash(org, 120);
 	for (i=-12 ; i<=12 ; i+=6)

--- a/source/psp/video_hardware_decals_QMB.cpp
+++ b/source/psp/video_hardware_decals_QMB.cpp
@@ -23,8 +23,6 @@ extern "C"
 {
 #include "../quakedef.h"
 }
-
-#include <list>
 #include <pspgu.h>
 
 #include "clipping.hpp"
@@ -32,8 +30,6 @@ extern "C"
 
 using namespace std;
 using namespace quake;
-
-list<int> TempDecalTextureList;
 
 #ifdef SLIM
 #define DEFAULT_NUM_DECALS      1024 //*4
@@ -115,23 +111,7 @@ void R_InitDecals (void)
 
 	if (!qmb_initialized)
 		return;
-/*
- decal_blood1  = loadtextureimage("textures/decals/blood_splat01",   0, 0, qfalse, GU_LINEAR);
- decal_blood2  = loadtextureimage("textures/decals/blood_splat02",   0, 0, qfalse, GU_LINEAR);
- decal_blood3  = loadtextureimage("textures/decals/blood_splat03",   0, 0, qfalse, GU_LINEAR);
- decal_q3blood = loadtextureimage("textures/decals/blood_stain",     0, 0, qfalse, GU_LINEAR);
- decal_burn    = loadtextureimage("textures/decals/explo_burn01",    0, 0, qfalse, GU_LINEAR);
- decal_mark    = loadtextureimage("textures/decals/particle_burn01", 0, 0, qfalse, GU_LINEAR);
- decal_glow    = loadtextureimage("textures/decals/glow2",           0, 0, qfalse, GU_LINEAR);
 
-	decal_blood1 = GL_LoadTextureImage ("textures/decals/blood_splat01", "decals:blood_splat01", 128, 128, TEX_ALPHA | TEX_COMPLAIN);
-	decal_blood2 = GL_LoadTextureImage ("textures/decals/blood_splat02", "decals:blood_splat02", 128, 128, TEX_ALPHA | TEX_COMPLAIN);
-	decal_blood3 = GL_LoadTextureImage ("textures/decals/blood_splat03", "decals:blood_splat03", 128, 128, TEX_ALPHA | TEX_COMPLAIN);
-	decal_q3blood = GL_LoadTextureImage ("textures/decals/blood_stain", "decals:blood_stain", 64, 64, TEX_ALPHA | TEX_COMPLAIN);
-	decal_burn = GL_LoadTextureImage ("textures/decals/explo_burn01", "decals:explo_burn01", 128, 128, TEX_ALPHA | TEX_COMPLAIN);
-	decal_mark = GL_LoadTextureImage ("textures/decals/particle_burn01", "decals:particle_burn01", 64, 64, TEX_ALPHA | TEX_COMPLAIN);
-	decal_glow = GL_LoadTextureImage ("textures/decals/glow2", "decals:glow2", 64, 64, TEX_ALPHA | TEX_COMPLAIN);
-*/
 	if ((i = COM_CheckParm("-decals")) && i + 1 < com_argc)
 	{
 		r_numdecals = Q_atoi(com_argv[i+1]);
@@ -167,12 +147,6 @@ void R_ClearDecals (void)
 
 	decals[r_numdecals-1].next = NULL;
 
-	while (TempDecalTextureList.size() > 0)
-	{
-		int index = TempDecalTextureList.front();
-		TempDecalTextureList.pop_front();
-		GL_UnloadTexture(index);
-	}
     wadreload = 1;
 }
 
@@ -402,19 +376,6 @@ void R_SpawnDecalBSP (vec3_t org, char *texname, int size)
 		{
 			return;
 		}
-	}
-
-	//don't free static decals
-	if((tex != decal_q3blood) &&
-	   (tex != decal_blood1)  &&
-	   (tex != decal_blood2)  &&
-	   (tex != decal_blood3)  &&
-	   (tex != decal_q3blood) &&
-	   (tex != decal_burn)    &&
-	   (tex != decal_mark)    &&
-	   (tex != decal_glow))
-	{
-	   TempDecalTextureList.push_back(tex); //write to list ,for unload
 	}
 
 	VectorClear (bestorg);

--- a/source/psp/video_hardware_draw.cpp
+++ b/source/psp/video_hardware_draw.cpp
@@ -528,27 +528,6 @@ void Draw_Init (void)
 	GL_MarkTextureAsPermanent(char_texture);
 	if (char_texture == 0)// did not find a matching TGA...
 		Sys_Error ("Could not load charset, make sure you have every folder and file installed properly\nDouble check that all of your files are in their correct places\nAnd that you have installed the game properly.\nRefer to the readme.txt file for help\n");
-
-	sniper_scope = Draw_CachePic ("gfx/hud/scope_256");
-	// GL_MarkTextureAsPermanent(sniper_scope);
-
-	zombie_skins[0][0] = loadtextureimage ("models/ai/zfull.mdl_0", 0, 0, qtrue, GU_LINEAR);
-	GL_MarkTextureAsPermanent(zombie_skins[0][0]);
-	// PSP PHAT: Only have 1 Zombie skin.. this saves 192kB of VRAM, well worth it.
-
-#ifdef SLIM
-
-	zombie_skins[0][1] = loadtextureimage ("models/ai/zfull.mdl_1", 0, 0, qtrue, GU_LINEAR);
-	zombie_skins[1][0] = loadtextureimage ("models/ai/zfull.mdl_2", 0, 0, qtrue, GU_LINEAR);
-	zombie_skins[1][1] = loadtextureimage ("models/ai/zfull.mdl_3", 0, 0, qtrue, GU_LINEAR);
-	GL_MarkTextureAsPermanent(zombie_skins[0][1]);
-	GL_MarkTextureAsPermanent(zombie_skins[1][0]);
-	GL_MarkTextureAsPermanent(zombie_skins[1][1]);
-#else
-	zombie_skins[0][1] = zombie_skins[0][0];
-	zombie_skins[1][0] = zombie_skins[0][0];
-	zombie_skins[1][1] = zombie_skins[0][0];
-#endif // SLIM
 	
 	Clear_LoadingFill ();
 }
@@ -3114,7 +3093,7 @@ int GL_LoadImages (const char *identifier, int width, int height, const byte *da
 		}
 		break;
 	}
-
+	
 	// HACK HACK: Force use of DXT5 for the mbox glow
 	char specChar = identifier[strlen(identifier) - 7];
 	if (specChar == '$')
@@ -3220,7 +3199,6 @@ int GL_LoadImages (const char *identifier, int width, int height, const byte *da
 	//FIXME: this isn't completely clearing out the normal ram stuff :s
 	if (texture.vram && texture.ram)
 	{
-		Con_Printf("Put %s into VRAM (%dkB)\n", identifier, buffer_size/1024);
 		free(texture.ram);
 		texture.ram = NULL;
 	} else {

--- a/source/psp/video_hardware_fog.cpp
+++ b/source/psp/video_hardware_fog.cpp
@@ -239,7 +239,7 @@ Fog_SetupFrame
 called at the beginning of each frame
 =============
 */
-void Fog_SetupFrame (void)
+void Fog_SetupFrame (bool worldgeom)
 {
 	float c[4];
 	float f, s, e;
@@ -268,7 +268,11 @@ void Fog_SetupFrame (void)
 	if(e == 0)
 		e = -1;
 
-	sceGuFog ( s, e, GU_COLOR( c[0]* 0.01f, c[1]* 0.01f, c[2]* 0.01f, c[3] ) );
+	// If we have normal color fog for world geom + lightmap, then the resulting color when fully fogged is wrong.
+	// If we have exactly 0.5 0.5 0.5 gray for world game and normal fog for lightmap, the end result of fully fogged
+	// stuff is the actual fog color.
+	unsigned int color = worldgeom ? GU_COLOR(0.5f, 0.5f, 0.5f, c[3]) : GU_COLOR(c[0]* 0.01f, c[1]* 0.01f, c[2]* 0.01f, c[3]);
+	sceGuFog(s, e, color);
 
 	if(s == 0 || e < 0)
 		sceGuDisable(GU_FOG);

--- a/source/psp/video_hardware_images.cpp
+++ b/source/psp/video_hardware_images.cpp
@@ -1088,6 +1088,34 @@ int loadtextureimage (char* filename, int matchwidth, int matchheight, qboolean 
 	return texture_index;
 }
 
+// Hacky thing to only load a top half of an image for skybox sides, hard to imagine other use for this
+int loadskyboxsideimage (char* filename, int matchwidth, int matchheight, qboolean complain, int filter)
+{
+	int texture_index;
+	byte *data;
+
+	int hunk_start = Hunk_LowMark();
+	data = loadimagepixels (filename, complain, matchwidth, matchheight);
+	int hunk_stop = Hunk_LowMark();
+
+	if(!data)
+	{
+		return 0;
+	}
+
+	int newheight = image_height * 0.5;
+	
+	texture_index = GL_LoadImages (filename, image_width, newheight, data, qtrue, filter, 0, 4);
+
+	// Only free the hunk if it was used.
+	if (hunk_start != hunk_stop)
+		Hunk_FreeToLowMark(hunk_start);
+	else
+		free(data);
+
+	return texture_index;
+}
+
 /*
 =============
 loadrgbafrompal

--- a/source/psp/video_hardware_main.cpp
+++ b/source/psp/video_hardware_main.cpp
@@ -38,7 +38,7 @@ using namespace quake;
 //prototypes
 extern "C" void V_CalcBlend (void);
 
-void Fog_SetupFrame (void);
+void Fog_SetupFrame (bool worldgeom);
 void Fog_EnableGFog (void); 
 void Fog_DisableGFog (void);
 void R_DrawDecals (void);
@@ -141,6 +141,7 @@ cvar_t  r_showbboxes_full     = {"r_showbboxes_full",         "0",qtrue};
 cvar_t	r_showtris            = {"r_showtris",                "0"};
 cvar_t	r_showtris_full       = {"r_showtris_full",           "0",qtrue};
 cvar_t	r_polyblend	          = {"r_polyblend",               "1",qtrue};
+cvar_t r_skyfogblend = {"r_skyfogblend", "0.6", qtrue}; 
 
 //QMB
 cvar_t  r_explosiontype     = {"r_explosiontype",    "0",qtrue};
@@ -3693,7 +3694,7 @@ void R_RenderScene (void)
 	vrect_t* renderrect = &r_refdef.vrect;
 
 	//setupframe
-	Fog_SetupFrame();
+	Fog_SetupFrame(false);
 	R_AnimateLight();
 	++r_framecount;
 
@@ -3789,7 +3790,8 @@ void R_RenderScene (void)
 		}
 	}
 
-	sceGumPerspective(fovy, fovx, 4, r_maxrange.value);
+	float farplanedist = (r_refdef.fog_start == 0 || r_refdef.fog_end < 0) ? 4096 : (r_refdef.fog_end + 16); 
+	sceGumPerspective(fovy, fovx, 4, farplanedist);
 
 	if (mirror)
 	{
@@ -3839,7 +3841,7 @@ void R_RenderScene (void)
 
 	sceGumMatrixMode(GU_PROJECTION);
 	sceGumLoadIdentity();
-	sceGumPerspective(fovy, fovx, 4, r_maxrange.value);
+	sceGumPerspective(fovy, fovx, 4, farplanedist);
 	sceGumUpdateMatrix();
 	sceGumMatrixMode(GU_MODEL);
 

--- a/source/psp/video_hardware_misc.cpp
+++ b/source/psp/video_hardware_misc.cpp
@@ -43,17 +43,29 @@ R_InitOtherTextures
 */
 void	R_InitOtherTextures (void)
 {
-	//static decals
-	decal_blood1  = loadtextureimage ("textures/decals/blood_splat01", 0, 0, qfalse, GU_LINEAR);
-	GL_MarkTextureAsPermanent(decal_blood1);
-	decal_blood2  = loadtextureimage ("textures/decals/blood_splat02", 0, 0, qfalse, GU_LINEAR);
-	GL_MarkTextureAsPermanent(decal_blood2);
-	decal_blood3  = loadtextureimage ("textures/decals/blood_splat03", 0, 0, qfalse, GU_LINEAR);
-	GL_MarkTextureAsPermanent(decal_blood3);
-    decal_q3blood = loadtextureimage ("textures/decals/blood_stain", 0, 0, qfalse, GU_LINEAR);
-	GL_MarkTextureAsPermanent(decal_blood1);
+	sniper_scope = Draw_CachePic ("gfx/hud/scope_256");
+
+	zombie_skins[0][0] = loadtextureimage ("models/ai/zfull.mdl_0", 0, 0, qtrue, GU_LINEAR);
+	GL_MarkTextureAsPermanent(zombie_skins[0][0]);
+	// PSP PHAT: Only have 1 Zombie skin.. this saves 192kB of VRAM, well worth it.
+
+#ifdef SLIM
+
+	zombie_skins[0][1] = loadtextureimage ("models/ai/zfull.mdl_1", 0, 0, qtrue, GU_LINEAR);
+	zombie_skins[1][0] = loadtextureimage ("models/ai/zfull.mdl_2", 0, 0, qtrue, GU_LINEAR);
+	zombie_skins[1][1] = loadtextureimage ("models/ai/zfull.mdl_3", 0, 0, qtrue, GU_LINEAR);
+	GL_MarkTextureAsPermanent(zombie_skins[0][1]);
+	GL_MarkTextureAsPermanent(zombie_skins[1][0]);
+	GL_MarkTextureAsPermanent(zombie_skins[1][1]);
+#else
+	zombie_skins[0][1] = zombie_skins[0][0];
+	zombie_skins[1][0] = zombie_skins[0][0];
+	zombie_skins[1][1] = zombie_skins[0][0];
+#endif // SLIM
+
 	decal_burn	  = loadtextureimage ("textures/decals/explo_burn01", 0, 0, qfalse, GU_LINEAR);
 	GL_MarkTextureAsPermanent(decal_burn);
+	decal_blood1 = decal_blood2 = decal_blood3 = decal_q3blood = decal_burn;
 	decal_mark	  = loadtextureimage ("textures/decals/particle_burn01", 0, 0, qfalse, GU_LINEAR);
 	GL_MarkTextureAsPermanent(decal_mark);
 	decal_glow	  = loadtextureimage ("textures/decals/glow2", 0, 0, qfalse, GU_LINEAR);
@@ -318,6 +330,7 @@ void R_Init (void)
 
 	Cvar_RegisterVariable (&r_fastsky);
 	Cvar_RegisterVariable (&r_skycolor);
+	Cvar_RegisterVariable (&r_skyfogblend);
 
 	Cvar_RegisterVariable (&r_loadq3models);
     Cvar_RegisterVariable (&r_farclip);

--- a/source/psp/video_hardware_surface.cpp
+++ b/source/psp/video_hardware_surface.cpp
@@ -93,6 +93,8 @@ void 	VID_SetPaletteLM();
 void 	VID_SetPaletteTX();
 // switch palette for textures
 
+void Fog_SetupFrame (bool worldgeom);
+
 /*
 ===============
 R_AddDynamicLights
@@ -1117,7 +1119,7 @@ static void DrawTextureChains (void)
 		if (!s)
 			continue;
 		if (i == skytexturenum)
-			R_DrawSkyChain (s);
+			continue; // R_DrawSkyChain (s);
 		else if (i == mirrortexturenum && r_mirroralpha.value != 1.0)
 		{
 			R_MirrorChain (s);
@@ -1586,20 +1588,21 @@ void R_DrawWorld (void)
 	num_lightmapped_faces = 0;
 
 	R_ClearSkyBox ();
+	if (strcmp(skybox_name, "") != 0)
+		R_DrawSkyBox();
 
 	R_RecursiveWorldNode (cl.worldmodel->nodes, false);
 
 	R_AddStaticBrushModelsToChains ();
 
+	Fog_SetupFrame(true);
 	DrawTextureChains ();
-
+	Fog_SetupFrame(false);
 	R_BlendLightmaps ();
 
 	//dr_mabuse1981: commented out, this was the one who caused the epic lag
     //DrawFullBrightTextures (cl.worldmodel->surfaces, cl.worldmodel->numsurfaces);
 	//dr_mabuse1981: commented out, this was the one who caused the epic lag
-	if (strcmp(skybox_name, "") != 0)
-		R_DrawSkyBox();
 }
 
 


### PR DESCRIPTION
There's also bunch of slightly unrelated changes to reduce vram use by other unused assets. This buys us enough vram to store every texture on ndu including sky in vram, and it means sky should be usable on phat too.