### PR TITLE
RVL: Add an overscan option for screen width

### DIFF
--- a/source/wii/gx/gxquake.h
+++ b/source/wii/gx/gxquake.h
@@ -243,7 +243,8 @@ extern  cvar_t  r_overbright;
 extern	cvar_t	gl_max_size;
 extern	cvar_t	gl_playermip;
 
-extern cvar_t vid_tvborder;
+extern cvar_t vid_overscan_height;
+extern cvar_t vid_overscan_width;
 extern cvar_t vid_retromode;
 
 extern  cvar_t	r_part_muzzleflash;

--- a/source/wii/gx/video_gx.c
+++ b/source/wii/gx/video_gx.c
@@ -60,7 +60,8 @@ static float vid_gamma = 1.0;
 Mtx44 perspective;
 Mtx view, model, modelview;
 
-cvar_t vid_tvborder = {"vid_tvborder", "0", (qboolean)true};
+cvar_t vid_overscan_height = {"vid_overscan_height", "0", (qboolean)true};
+cvar_t vid_overscan_width = {"vid_overscan_width", "0", (qboolean)true};
 cvar_t vid_conmode = {"vid_conmode", "0", (qboolean)true};
 
 void D_BeginDirectRect (int x, int y, byte *pbitmap, int width, int height)
@@ -235,16 +236,12 @@ GL_BeginRendering
 void GL_BeginRendering (int *x, int *y, int *width, int *height)
 {
 	// ELUTODO: lol at the * 2 on height
-	*x = 0;
-	*y = vid_tvborder.value * 200;
+	*x = vid_overscan_width.value * 200;
+	*y = vid_overscan_height.value * 200;
 	*width = scr_width;
-	*height = scr_height - (vid_tvborder.value * 400);
+	*height = scr_height - (vid_overscan_height.value * 400);
 
-	GX_SetScissor(*x,*y,*width > 640 ? 640 : *width,*height);
-	
-	// ELUTODO: really necessary?
-	//GX_InvVtxCache();
-	//GX_InvalidateTexAll();
+	GX_SetScissor(*x,*y,*width > 640 ? 640 - (vid_overscan_width.value * 360) : *width - (vid_overscan_width.value * 360),*height);
 }
 
 void GL_EndRendering (void)
@@ -334,7 +331,8 @@ void VID_Init(unsigned char *palette)
 
 	vid.recalc_refdef = 1;				// force a surface cache flush
 
-	Cvar_RegisterVariable(&vid_tvborder);
+	Cvar_RegisterVariable(&vid_overscan_height);
+	Cvar_RegisterVariable(&vid_overscan_width);
 	Cvar_RegisterVariable(&vid_retromode);
 	Cvar_RegisterVariable(&vid_conmode);
 

--- a/source/wii/menu.c
+++ b/source/wii/menu.c
@@ -1868,7 +1868,7 @@ again:
 //=============================================================================
 /* OPTIONS MENU */
 
-#define	OPTIONS_ITEMS	15
+#define	OPTIONS_ITEMS	16
 
 #define	SLIDER_RANGE	10
 
@@ -1949,15 +1949,23 @@ void M_AdjustSliders (int dir)
 	case 12:	// weapon roll by input
 		Cvar_SetValue ("cl_weapon_inrollangle", !cl_weapon_inrollangle.value);
 		break;
-	case 13:	// tv border
-		vid_tvborder.value += dir * 0.005f;
-		if (vid_tvborder.value < 0)
-			vid_tvborder.value = 0;
-		if (vid_tvborder.value > 0.2)
-			vid_tvborder.value = 0.2;
-		Cvar_SetValue ("vid_tvborder", vid_tvborder.value);
-		break;		
-	case 14:	// retro mode
+	case 13:	// height overscan
+		vid_overscan_height.value += dir * 0.005f;
+		if (vid_overscan_height.value < 0)
+			vid_overscan_height.value = 0;
+		if (vid_overscan_height.value > 0.2)
+			vid_overscan_height.value = 0.2;
+		Cvar_SetValue ("vid_overscan_height", vid_overscan_height.value);
+		break;	
+	case 14:	// width overscan
+		vid_overscan_width.value += dir * 0.0025f;
+		if (vid_overscan_width.value < 0)
+			vid_overscan_width.value = 0;
+		if (vid_overscan_width.value > 0.1)
+			vid_overscan_width.value = 0.1;
+		Cvar_SetValue ("vid_overscan_width", vid_overscan_width.value);
+		break;
+	case 15:	// retro mode
 		Cvar_SetValue ("vid_retromode", !vid_retromode.value);
 		break;
 	}
@@ -2039,12 +2047,16 @@ void M_Options_Draw (void)
 	M_PrintScaled (16, 184, "Weapon Roll");
 	M_DrawCheckbox (215, 184, cl_weapon_inrollangle.value);
 
-	M_PrintScaled (16, 196, "TV Overscan");
-	r = vid_tvborder.value / 0.2f;
+	M_PrintScaled (16, 196, "TV Height Overscan");
+	r = vid_overscan_height.value / 0.2f;
 	M_DrawSlider (220, 196, r);
 	
-	M_PrintScaled (16, 208, "Retro Mode");
-	M_DrawCheckbox (215, 208, vid_retromode.value);
+	M_PrintScaled (16, 208, "TV Width Overscan");
+	r = vid_overscan_width.value / 0.1f;
+	M_DrawSlider (220, 208, r);
+	
+	M_PrintScaled (16, 220, "Retro Mode");
+	M_DrawCheckbox (215, 220, vid_retromode.value);
 
 // cursor
 	M_DrawCharacterScaled (200, 40 + options_cursor*12, 12+((int)(realtime*4)&1));


### PR DESCRIPTION
### Description of Changes
---
Adds a new settings option to adjust the picture width in order to accommodate tv or monitor used

### Visual Sample
---
![image](https://github.com/user-attachments/assets/019b8e98-1ad4-47c4-bed1-885bf6b0653f)

### Checklist
---

- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact Nazi Zombies: Portable's licensing and usage
- [ ] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
