### PR TITLE
PSP: Fix devices w/o right stick constantly moving

### DIFF
--- a/source/nzportable_def.h
+++ b/source/nzportable_def.h
@@ -42,14 +42,6 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #define qfalse 0
 #endif // __PSP__
 
-#ifdef __PSP__
-#define PSP_MODEL_PHAT		0
-#define PSP_MODEL_SLIM 		1
-#define PSP_MODEL_PSVITA 	2
-
-extern int psp_system_model;
-#endif // __PSP__
-
 #define	QUAKE_GAME			// as opposed to utilities
 
 #define	VERSION				2.0

--- a/source/platform/psp/input.cpp
+++ b/source/platform/psp/input.cpp
@@ -71,6 +71,8 @@ extern float crosshair_opacity;
 extern cvar_t in_anub_mode;
 extern cvar_t in_mlook; //Heffo - mlook cvar
 
+extern bool system_has_right_stick;
+
 void IN_Init (void)
 {
 	// Set up the controller.
@@ -319,6 +321,10 @@ void IN_Move (usercmd_t *cmd)
 	} else { // Right
 		look_x = IN_CalcInput(pad.Rsrv[0], speed, deadZone, acceleration);
 		look_y = IN_CalcInput(pad.Rsrv[1], speed, deadZone, acceleration) * -1;
+
+		if (!system_has_right_stick) {
+			look_x = look_y = 0;
+		}
 	}
 
 	const float yawScale = 30.0f;
@@ -346,6 +352,10 @@ void IN_Move (usercmd_t *cmd)
 	} else {
 		input_x = pad.Rsrv[0];
 		input_y = 255 - pad.Rsrv[1];
+
+		if (!system_has_right_stick) {
+			input_x = input_y = 128;
+		}
 	}
 
 	cl_backspeed = cl_forwardspeed = cl_sidespeed = sv_player->v.maxspeed;

--- a/source/platform/psp/main.cpp
+++ b/source/platform/psp/main.cpp
@@ -42,6 +42,8 @@ extern "C"
 #include "thread.h"
 #include "m33libs/kubridge.h"
 void VramSetSize(int kb);
+int psp_system_model;
+bool system_has_right_stick;
 }
 
 #include "battery.hpp"
@@ -55,8 +57,6 @@ qboolean depthfl = qfalse;
 
 extern	int  com_argc;
 extern	char **com_argv;
-
-int psp_system_model;
 
 void Sys_ReadCommandLineFile (char* netpath);
 
@@ -513,6 +513,8 @@ int user_main(SceSize argc, void* argp)
 	setUpCallbackThread();
 
 	psp_system_model = Sys_GetPSPModel();
+	system_has_right_stick = Sys_HasRightStick();
+
 
 	// Disable floating point exceptions.
 	// If this isn't done, Quake crashes from (presumably) divide by zero
@@ -734,18 +736,48 @@ void Sys_ReadCommandLineFile (char* netpath)
 
 int Sys_GetPSPModel(void) 
 {
-	// pspemu has this module on its flash0 partition
+	// PS VITA's pspemu exclussively has this module on its flash0 partition,
+	// Credit to DaedalusX64 for this concept.
 	int vitaprx = sceIoOpen("flash0:/kd/registry.prx", PSP_O_RDONLY | PSP_O_WRONLY, 0777);
-
 	if (vitaprx >= 0) {
 		sceIoClose(vitaprx);
 		return PSP_MODEL_PSVITA;
 	}
 
+#if 0
+	// PPSSPP will return zero (success) for trying to read the emulator: device,
+	// Credit to Linblow for this concept.
+	int device_result = 0;
+	int device_ret = sceIoDevctl("emulator:", 3, &device_result, 0, NULL, 0);
+	if (device_result == 0) return PSP_MODEL_EMULATED;
+#endif
+
+	// Use kuBridge and trust the Kernel to report the system model.
 	int model = kuKernelGetModel();
+	switch (model) {
+		case 0: return PSP_MODEL_PHAT;
+		case 1: return PSP_MODEL_SLIM;
+		case 2: return PSP_MODEL_BRITE;
+		case 4: return PSP_MODEL_GO;
+		case 10: return PSP_MODEL_STREET;
+		default: break;
+	}
 
-	if (model == 0)
-		return PSP_MODEL_PHAT;
+	// Fallback.
+	return PSP_MODEL_UNKNOWN;
+}
 
-	return PSP_MODEL_SLIM;
+bool Sys_HasRightStick(void)
+{
+	int psp_system_model = Sys_GetPSPModel();
+	if (psp_system_model == PSP_MODEL_PSVITA /*|| psp_system_model == PSP_MODEL_EMULATED*/) {
+		return true;
+	} else /*if (psp_system_model == PSP_MODEL_GO)*/ {
+		SceCtrlData pad;
+		sceCtrlPeekBufferPositive(&pad, 1);
+		if (pad.Rsrv[0] != 0 && pad.Rsrv[1] != 0) {
+			return true;
+		}
+	}
+	return false;
 }

--- a/source/platform/psp/sys.h
+++ b/source/platform/psp/sys.h
@@ -19,6 +19,17 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 */
 // sys.h -- non-portable functions
 
+#define PSP_MODEL_PHAT		0
+#define PSP_MODEL_SLIM 		1
+#define PSP_MODEL_BRITE     2
+#define PSP_MODEL_GO        3
+#define PSP_MODEL_STREET    4
+#define PSP_MODEL_PSVITA 	5
+#define PSP_MODEL_EMULATED  6
+#define PSP_MODEL_UNKNOWN   100
+
+extern int psp_system_model;
+
 //
 // file IO
 //
@@ -75,5 +86,6 @@ void Sys_SetFPCW (void);
 
 // returns psp model
 int Sys_GetPSPModel(void);
+bool Sys_HasRightStick(void);
 
 void Sys_CaptureScreenshot(void);

--- a/source/platform/psp/system.cpp
+++ b/source/platform/psp/system.cpp
@@ -340,9 +340,14 @@ void Sys_PrintSystemInfo(void)
 	Con_Printf ("%4.1f megabyte PSP application heap \n",1.0f * PSP_HEAP_SIZE_MB);
 
 	switch(psp_system_model) {
-		case PSP_MODEL_PHAT: Con_Printf("PSP Model: PSP-1000 model unit\n"); break;
-		case PSP_MODEL_SLIM: Con_Printf("PSP Model: PSP-SLIM model unit\n"); break;
+		case PSP_MODEL_PHAT: Con_Printf("PSP Model: PSP-FAT (1000)\n"); break;
+		case PSP_MODEL_SLIM: Con_Printf("PSP Model: PSP-SLIM (2000)\n"); break;
+		case PSP_MODEL_BRITE: Con_Printf("PSP Model: PSP-BRITE (3000)\n"); break;
+		case PSP_MODEL_GO: Con_Printf("PSP Model: PSP-GO (4000)\n"); break;
+		case PSP_MODEL_STREET: Con_Printf("PSP Model: PSP-STREET (E-1000)\n"); break;
 		case PSP_MODEL_PSVITA: Con_Printf("PSP Model: PS VITA model unit\n"); break;
+		case PSP_MODEL_EMULATED: Con_Printf("PSP Model: Emulated\n"); break;
+		case PSP_MODEL_UNKNOWN: Con_Printf("PSP Model: Unknown (Please report this!)\n"); break;
 		default: break;
 	}
 


### PR DESCRIPTION
<!-- Note that before you open this Pull Request it should be titled to fit our standard, using prefixes specifying platform relevancy:
* `PSP`: PlayStation Portable
* `CTR`: Nintendo 3DS
* `RVL`: Nintendo Wii

If commits generally are common, use the `GLOBAL` prefix.

Examples:
PSP: Add super cool texture compression for 2x rendering performance!
GLOBAL: Fix crc built-in using wrong crc algorithm
CTR/RVL: Conform to DevkitPro code standards

Ideally you should also use this standard for your commit names too. They'll likely be squashed on merge if they do not conform.
-->

### Description of Changes
---
Because of Sony treating 128,128 as the point of center for analog movement, and the default Rx and Ry being 0,0 when no device is present, users without compatible hardware were constantly forced to move South West. This PR fixes that by detecting the presence of a right stick and gating out use if one doesnt exist.
<!-- Replace this text with an overview of your changes made in this Pull Request. Please use your best judgement here, do not be verbose to the point that you are giving an exact step-by-step of your workflow, but do not undersell the changes made. If this Pull Request addresses an open issue, you should reference that too. -->

### Visual Sample
---
N/A, but verified on PSP-1000 and PS VITA.
<!-- Replace this text with a media attachment or code test snippet that demonstrates the functionality of your changes. Please be mindful that GitHub is a platform for everyone, refrain from sending big attachments that could take a very long time to download for users with slow internet speeds. -->

### Checklist
---

- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact Nazi Zombies: Portable's licensing and usage
- [x] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible