### PR TITLE
CTR: Create and initialize touch control keys

### DIFF
--- a/source/keys.c
+++ b/source/keys.c
@@ -88,6 +88,11 @@ keyname_t keynames[] =
 	{"DELETE", K_DELETE},
 
 	{"TOUCH", K_TOUCH},
+	{"TOUCH1", K_TOUCH1},
+	{"TOUCH2", K_TOUCH2},
+	{"TOUCH3", K_TOUCH3},
+	{"TOUCH4", K_TOUCH4},
+	{"TOUCH5", K_TOUCH5},
 	
 	{"SPACE", K_SPACE},
 
@@ -655,6 +660,11 @@ void Key_Init (void)
 	consolekeys[K_DELETE] = true;
 
 	consolekeys[K_TOUCH] = true;
+	consolekeys[K_TOUCH1] = true;
+	consolekeys[K_TOUCH2] = true;
+	consolekeys[K_TOUCH3] = true;
+	consolekeys[K_TOUCH4] = true;
+	consolekeys[K_TOUCH5] = true;
 
 	consolekeys[K_JOY1] = true;
 	consolekeys[K_JOY2] = true;

--- a/source/keys.c
+++ b/source/keys.c
@@ -88,11 +88,11 @@ keyname_t keynames[] =
 	{"DELETE", K_DELETE},
 
 	{"TOUCH", K_TOUCH},
-	{"TOUCH1", K_TOUCH1},
-	{"TOUCH2", K_TOUCH2},
-	{"TOUCH3", K_TOUCH3},
-	{"TOUCH4", K_TOUCH4},
-	{"TOUCH5", K_TOUCH5},
+	{"TOUCH1", K_TOUCHACTION1},
+	{"TOUCH2", K_TOUCHACTION2},
+	{"TOUCH3", K_TOUCHACTION3},
+	{"TOUCH4", K_TOUCHACTION4},
+	{"TOUCH5", K_TOUCHACTION5},
 	
 	{"SPACE", K_SPACE},
 
@@ -660,11 +660,11 @@ void Key_Init (void)
 	consolekeys[K_DELETE] = true;
 
 	consolekeys[K_TOUCH] = true;
-	consolekeys[K_TOUCH1] = true;
-	consolekeys[K_TOUCH2] = true;
-	consolekeys[K_TOUCH3] = true;
-	consolekeys[K_TOUCH4] = true;
-	consolekeys[K_TOUCH5] = true;
+	consolekeys[K_TOUCHACTION1] = true;
+	consolekeys[K_TOUCHACTION2] = true;
+	consolekeys[K_TOUCHACTION3] = true;
+	consolekeys[K_TOUCHACTION4] = true;
+	consolekeys[K_TOUCHACTION5] = true;
 
 	consolekeys[K_JOY1] = true;
 	consolekeys[K_JOY2] = true;

--- a/source/keys.h
+++ b/source/keys.h
@@ -58,11 +58,11 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 
 // PSP2/CTR
 #define K_TOUCH         159
-#define K_TOUCH1        160
-#define K_TOUCH2        161
-#define K_TOUCH3        162
-#define K_TOUCH4        163
-#define K_TOUCH5        164
+#define K_TOUCHACTION1  160
+#define K_TOUCHACTION2  161
+#define K_TOUCHACTION3  162
+#define K_TOUCHACTION4  163
+#define K_TOUCHACTION5  164
 
 // Joystick buttons
 #define	K_JOY1			184

--- a/source/keys.h
+++ b/source/keys.h
@@ -56,8 +56,13 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 #define K_TAB           157
 #define K_DELETE        158
 
-// PSP2
+// PSP2/CTR
 #define K_TOUCH         159
+#define K_TOUCH1        160
+#define K_TOUCH2        161
+#define K_TOUCH3        162
+#define K_TOUCH4        163
+#define K_TOUCH5        164
 
 // Joystick buttons
 #define	K_JOY1			184

--- a/source/platform/ctr/touch_ctr.c
+++ b/source/platform/ctr/touch_ctr.c
@@ -81,7 +81,7 @@ void Touch_Update(){
 void Touch_SideBarTap()
 {
   uint16_t y = (touch.py - 14)/42;
-  lastKey = K_TOUCH1 + y;
+  lastKey = K_TOUCHACTION1 + y;
   Key_Event(lastKey, true);
 }
 

--- a/source/platform/ctr/touch_ctr.c
+++ b/source/platform/ctr/touch_ctr.c
@@ -81,7 +81,7 @@ void Touch_Update(){
 void Touch_SideBarTap()
 {
   uint16_t y = (touch.py - 14)/42;
-  lastKey = K_AUX9 + y;
+  lastKey = K_TOUCH1 + y;
   Key_Event(lastKey, true);
 }
 


### PR DESCRIPTION
<!-- Note that before you open this Pull Request it should be titled to fit our standard, using prefixes specifying platform relevancy:
* `PSP`: PlayStation Portable
* `CTR`: Nintendo 3DS
* `RVL`: Nintendo Wii
* `TNS`: TI-Nspire

If commits generally are common, use the `GLOBAL` prefix.

Examples:
PSP: Add super cool texture compression for 2x rendering performance!
GLOBAL: Fix crc built-in using wrong crc algorithm
CTR/RVL: Conform to DevkitPro code standards

Ideally you should also use this standard for your commit names too. They'll likely be squashed on merge if they do not conform.
-->

### Description of Changes
---
Creates and initializes keys for CTR/PSP2 touch screen controls

### Visual Sample
---
N/A

### Checklist
---

- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact Nazi Zombies: Portable's licensing and usage
- [x] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
