### PR TITLE
CTR: Add support for c-nub and circle pad pro in Controls menu

### DIFF
--- a/source/menu/menu_controls.c
+++ b/source/menu/menu_controls.c
@@ -22,20 +22,22 @@ Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
 //=============================================================================
 /* CONTROLS MENU */
 
-char* aimassist_string;
-char* invert_string;
-char *anub_string;
+char			*aimassist_string;
+char			*invert_string;
+char 			*anub_string;
 
 cvar_t			global_sensitivity;
+
+qboolean		has_anub = false;
 
 extern cvar_t 	in_aimassist;
 #ifdef __PSP__
 extern cvar_t	in_sensitivity;
-extern cvar_t	in_tolerance;
 #else
 extern cvar_t	sensitivity;
 #endif // __PSP__
 extern cvar_t	in_acceleration;
+extern cvar_t	in_tolerance;
 extern cvar_t	in_anub_mode;
 extern cvar_t	m_pitch;
 
@@ -48,6 +50,14 @@ void Menu_Controls_Set (void)
 {
 	Menu_ResetMenuButtons();
 
+#ifdef __PSP__
+	has_anub = true;
+#elif __3DS__
+	if (circlepadpro_flag || new3ds_flag) {
+		has_anub = true;
+	}
+#endif
+
     m_previous_state = m_configuration;
 	m_state = m_controls;
 }
@@ -56,12 +66,6 @@ void Menu_Controls_SetStrings (void)
 {
 #ifdef __PSP__
 	global_sensitivity = in_sensitivity;
-
-	if((int)in_anub_mode.value == 1) {
-		anub_string = "MOVE";
-	} else {
-		anub_string = "LOOK";
-	}
 #else
 	global_sensitivity = sensitivity;
 #endif
@@ -76,6 +80,14 @@ void Menu_Controls_SetStrings (void)
 		invert_string = "ENABLED";
 	} else {
 		invert_string = "DISABLED";
+	}
+
+	if (has_anub) {
+		if((int)in_anub_mode.value == 1) {
+			anub_string = "MOVE";
+		} else {
+			anub_string = "LOOK";
+		}
 	}
 }
 
@@ -158,15 +170,15 @@ void Menu_Controls_Draw (void)
 	Menu_DrawButton (controls_buttons++, controls_index++, "INVERT LOOK", "Invert Y-Axis Camera Input.", Menu_Controls_ApplyLookInversion);
 	Menu_DrawOptionButton (controls_buttons-1, invert_string);
 
-#ifdef __PSP__
-	// Anub tolerance
-	Menu_DrawButton (controls_buttons++, controls_index++, "A-NUB TOLERANCE", "Change A-Nub Tolerance.", NULL);
-	Menu_DrawOptionSlider (controls_buttons-1, controls_index-1, 0, 1, in_tolerance, "tolerance", false, true, 0.25f);
+	if (has_anub) {
+		// Anub tolerance
+		Menu_DrawButton (controls_buttons++, controls_index++, "A-NUB TOLERANCE", "Change A-Nub Tolerance.", NULL);
+		Menu_DrawOptionSlider (controls_buttons-1, controls_index-1, 0, 1, in_tolerance, "tolerance", false, true, 0.25f);
 
-	// Anub-mode (look/move)
-	Menu_DrawButton (controls_buttons++, controls_index++, "A-NUB MODE", "Toggle between Look and Move A-Nub Options.", Menu_Controls_ApplyAnubMode);
-	Menu_DrawOptionButton (controls_buttons-1, anub_string);
-#endif
+		// Anub-mode (look/move)
+		Menu_DrawButton (controls_buttons++, controls_index++, "A-NUB MODE", "Toggle between Look and Move A-Nub Options.", Menu_Controls_ApplyAnubMode);
+		Menu_DrawOptionButton (controls_buttons-1, anub_string);
+	}
 
 	// Bindings
 	Menu_DrawButton (controls_buttons++, controls_index++, "BINDINGS", "Change Input Bindings.", Menu_Bindings_Set);


### PR DESCRIPTION
<!-- Note that before you open this Pull Request it should be titled to fit our standard, using prefixes specifying platform relevancy:
* `PSP`: PlayStation Portable
* `CTR`: Nintendo 3DS
* `RVL`: Nintendo Wii
* `TNS`: TI-Nspire

If commits generally are common, use the `GLOBAL` prefix.

Examples:
PSP: Add super cool texture compression for 2x rendering performance!
GLOBAL: Fix crc built-in using wrong crc algorithm
CTR/RVL: Conform to DevkitPro code standards

Ideally you should also use this standard for your commit names too. They'll likely be squashed on merge if they do not conform.
-->

### Description of Changes
---
Adds two options in Controls menu to choose if the second stick is used for look/move, and to change the input tolerance.

### Visual Sample
---
N/A

### Checklist
---

- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact Nazi Zombies: Portable's licensing and usage
- [x] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
