### PR TITLE
GLOBAL: Correctly set option slider indices in game settings menu

### DIFF
--- a/source/menu/menu_gamesettings.c
+++ b/source/menu/menu_gamesettings.c
@@ -205,7 +205,7 @@ void Menu_GameSettings_Draw (void)
 
     // Start Round slider
     Menu_DrawButton(3, 1, "START ROUND", startround_string, NULL);
-    Menu_DrawOptionSlider(3, 2, 0, 50, sv_startround, "sv_startround", true, true, 5.0f);
+    Menu_DrawOptionSlider(3, 1, 0, 50, sv_startround, "sv_startround", true, true, 5.0f);
 
     // Magic button
     Menu_DrawButton(4, 2, "MAGIC", "Whether to allow Perks, Power-Ups, and the Mystery Box.", Menu_GameSettings_ApplyMagic);
@@ -217,7 +217,7 @@ void Menu_GameSettings_Draw (void)
 
     // Horde Size slider
     Menu_DrawButton(6, 4, "HORDE SIZE", "Maximum Zombies that can Active at once.", NULL);
-    Menu_DrawOptionSlider(6, 5, 2, 64, sv_maxai, "sv_maxai", false, true, 2.0f);
+    Menu_DrawOptionSlider(6, 4, 2, 64, sv_maxai, "sv_maxai", false, true, 2.0f);
 
     // Fast Rounds button
     Menu_DrawButton(7, 5, "FAST ROUNDS", "Minimize Time between Rounds.", Menu_GameSettings_ApplyFastRounds);


### PR DESCRIPTION
<!-- Note that before you open this Pull Request it should be titled to fit our standard, using prefixes specifying platform relevancy:
* `PSP`: PlayStation Portable
* `CTR`: Nintendo 3DS
* `RVL`: Nintendo Wii
* `TNS`: TI-Nspire

If commits generally are common, use the `GLOBAL` prefix.

Examples:
PSP: Add super cool texture compression for 2x rendering performance!
GLOBAL: Fix crc built-in using wrong crc algorithm
CTR/RVL: Conform to DevkitPro code standards

Ideally you should also use this standard for your commit names too. They'll likely be squashed on merge if they do not conform.
-->

### Description of Changes
---
Fixes a bug where sliders would be updated in incorrect game settings menu positions

### Visual Sample
---
<img width="1159" height="743" alt="image" src="https://github.com/user-attachments/assets/30534e4a-586b-446c-9008-b108367b9a39" />

### Checklist
---

- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact Nazi Zombies: Portable's licensing and usage
- [x] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
