### PR TITLE
3DS: gyro settings, OG 3DS fixes, and controls layout cleanup

### DIFF
--- a/source/cl_main.c
+++ b/source/cl_main.c
@@ -56,6 +56,15 @@ cvar_t	m_side = {"m_side","0.8", true};
 cvar_t	in_disable_analog = {"in_disable_analog", "0", true};
 cvar_t	in_anub_mode = {"in_anub_mode", "0", true};
 
+#ifdef __3DS__
+cvar_t	gyro_enable            = {"gyro_enable",            "0",   true};
+cvar_t	gyro_sensitivity       = {"gyro_sensitivity",       "1.0", true};
+cvar_t	gyro_pitch_sensitivity = {"gyro_pitch_sensitivity", "1.0", true};
+cvar_t	gyro_yaw_sensitivity   = {"gyro_yaw_sensitivity",   "1.0", true};
+cvar_t	gyro_invert_pitch      = {"gyro_invert_pitch",      "1",   true};
+cvar_t	gyro_invert_yaw        = {"gyro_invert_yaw",        "1",   true};
+#endif
+
 cvar_t 	cl_hitmarkers = {"cl_hitmarkers", "1", true};
 cvar_t 	cl_colorblind = {"cl_colorblind", "0", true};
 cvar_t 	cl_textopacity = {"cl_textopacity", "0.20", true};
@@ -1037,6 +1046,15 @@ void CL_Init (void)
 	Cvar_RegisterVariable (&in_acceleration);
 	Cvar_RegisterVariable (&in_disable_analog);
 	Cvar_RegisterVariable (&in_anub_mode);
+
+#ifdef __3DS__
+	Cvar_RegisterVariable (&gyro_enable);
+	Cvar_RegisterVariable (&gyro_sensitivity);
+	Cvar_RegisterVariable (&gyro_pitch_sensitivity);
+	Cvar_RegisterVariable (&gyro_yaw_sensitivity);
+	Cvar_RegisterVariable (&gyro_invert_pitch);
+	Cvar_RegisterVariable (&gyro_invert_yaw);
+#endif
 	
 #ifdef __WII__
 	Cvar_RegisterVariable (&ads_center);

--- a/source/menu/menu_controls.c
+++ b/source/menu/menu_controls.c
@@ -41,6 +41,20 @@ extern cvar_t	in_tolerance;
 extern cvar_t	in_anub_mode;
 extern cvar_t	m_pitch;
 
+#ifdef __3DS__
+// Gyroscope aiming feature added by Yassine Milal.
+extern cvar_t	gyro_enable;
+extern cvar_t	gyro_sensitivity;
+extern cvar_t	gyro_pitch_sensitivity;
+extern cvar_t	gyro_yaw_sensitivity;
+extern cvar_t	gyro_invert_pitch;
+extern cvar_t	gyro_invert_yaw;
+char			*gyro_string;
+char			*gyro_invert_pitch_string;
+char			*gyro_invert_yaw_string;
+qboolean		controls_gyro_submenu = false;
+#endif
+
 /*
 ===============
 Menu_Controls_Set
@@ -49,10 +63,12 @@ Menu_Controls_Set
 void Menu_Controls_Set (void)
 {
 	Menu_ResetMenuButtons();
+	has_anub = false;
 
 #ifdef __PSP__
 	has_anub = true;
 #elif __3DS__
+	controls_gyro_submenu = false;
 	if (circlepadpro_flag || new3ds_flag) {
 		has_anub = true;
 	}
@@ -89,6 +105,26 @@ void Menu_Controls_SetStrings (void)
 			anub_string = "LOOK";
 		}
 	}
+
+#ifdef __3DS__
+	if ((int)gyro_enable.value == 1) {
+		gyro_string = "ENABLED";
+	} else {
+		gyro_string = "DISABLED";
+	}
+
+	if ((int)gyro_invert_pitch.value == 1) {
+		gyro_invert_pitch_string = "ENABLED";
+	} else {
+		gyro_invert_pitch_string = "DISABLED";
+	}
+
+	if ((int)gyro_invert_yaw.value == 1) {
+		gyro_invert_yaw_string = "ENABLED";
+	} else {
+		gyro_invert_yaw_string = "DISABLED";
+	}
+#endif
 }
 
 void Menu_Controls_ApplyAimAssist (void)
@@ -127,6 +163,47 @@ void Menu_Controls_ApplyAnubMode (void)
     Cvar_SetValue ("in_anub_mode", current_anubmode);
 }
 
+#ifdef __3DS__
+void Menu_Controls_ApplyGyro (void)
+{
+	float current_gyro = gyro_enable.value;
+	current_gyro += 1;
+	if (current_gyro > 1)
+		current_gyro = 0;
+	Cvar_SetValue("gyro_enable", current_gyro);
+}
+
+void Menu_Controls_ApplyGyroInvertPitch (void)
+{
+	float val = gyro_invert_pitch.value;
+	val += 1;
+	if (val > 1)
+		val = 0;
+	Cvar_SetValue("gyro_invert_pitch", val);
+}
+
+void Menu_Controls_ApplyGyroInvertYaw (void)
+{
+	float val = gyro_invert_yaw.value;
+	val += 1;
+	if (val > 1)
+		val = 0;
+	Cvar_SetValue("gyro_invert_yaw", val);
+}
+
+void Menu_Controls_OpenGyroSubmenu (void)
+{
+	controls_gyro_submenu = true;
+	Menu_ResetMenuButtons();
+}
+
+void Menu_Controls_CloseGyroSubmenu (void)
+{
+	controls_gyro_submenu = false;
+	Menu_ResetMenuButtons();
+}
+#endif
+
 void Menu_Controls_ApplySettings (void)
 {
     // no op
@@ -147,12 +224,20 @@ void Menu_Controls_Draw (void)
 	Menu_DrawCustomBackground (true);
 
 	// Header
+	#ifdef __3DS__
+	Menu_DrawTitle (controls_gyro_submenu ? "GYRO OPTIONS" : "CONTROL OPTIONS", MENU_COLOR_WHITE);
+	#else
 	Menu_DrawTitle ("CONTROL OPTIONS", MENU_COLOR_WHITE);
+	#endif
 
 	Menu_Controls_SetStrings();
 
 	// Map panel makes the background darker
     Menu_DrawMapPanel();
+
+#ifdef __3DS__
+	if (!controls_gyro_submenu) {
+#endif
 
 	// Aim Assist
 	Menu_DrawButton (controls_buttons++, controls_index++, "AIM ASSIST", "Toggle Assisted-Aim to Improve Targetting.", Menu_Controls_ApplyAimAssist);
@@ -180,8 +265,57 @@ void Menu_Controls_Draw (void)
 		Menu_DrawOptionButton (controls_buttons-1, anub_string);
 	}
 
+#ifdef __3DS__
+	// Open dedicated gyro submenu to avoid controls list overlap.
+	Menu_DrawButton (controls_buttons++, controls_index++, "GYRO SETTINGS",
+		"Open Gyroscope Settings.", Menu_Controls_OpenGyroSubmenu);
+	Menu_DrawOptionButton (controls_buttons-1, gyro_string);
+#endif
+
 	// Bindings
 	Menu_DrawButton (controls_buttons++, controls_index++, "BINDINGS", "Change Input Bindings.", Menu_Bindings_Set);
+
+#ifdef __3DS__
+	} else {
+		Menu_DrawButton (controls_buttons++, controls_index++, "BACK TO CONTROLS",
+			"Return to Control Options.", Menu_Controls_CloseGyroSubmenu);
+
+		// ---- Gyroscope Settings ----
+
+		// Gyro Enable
+		Menu_DrawButton (controls_buttons++, controls_index++, "GYRO AIMING",
+			"Enable Gyroscope Aiming.", Menu_Controls_ApplyGyro);
+		Menu_DrawOptionButton (controls_buttons-1, gyro_string);
+
+		// Gyro Sensitivity
+		Menu_DrawButton (controls_buttons++, controls_index++, "GYRO SENSITIVITY",
+			"Overall Gyroscope Sensitivity.", NULL);
+		Menu_DrawOptionSlider (controls_buttons-1, controls_index-1,
+			0.1f, 5.0f, gyro_sensitivity, "gyro_sensitivity", false, true, 0.1f);
+
+		// Gyro Yaw Sensitivity
+		Menu_DrawButton (controls_buttons++, controls_index++, "GYRO YAW SENS",
+			"Gyroscope Horizontal Sensitivity.", NULL);
+		Menu_DrawOptionSlider (controls_buttons-1, controls_index-1,
+			0.1f, 3.0f, gyro_yaw_sensitivity, "gyro_yaw_sensitivity", false, true, 0.1f);
+
+		// Gyro Pitch Sensitivity
+		Menu_DrawButton (controls_buttons++, controls_index++, "GYRO PITCH SENS",
+			"Gyroscope Vertical Sensitivity.", NULL);
+		Menu_DrawOptionSlider (controls_buttons-1, controls_index-1,
+			0.1f, 3.0f, gyro_pitch_sensitivity, "gyro_pitch_sensitivity", false, true, 0.1f);
+
+		// Gyro Invert Pitch
+		Menu_DrawButton (controls_buttons++, controls_index++, "GYRO INVERT PITCH",
+			"Invert Gyroscope Vertical Axis.", Menu_Controls_ApplyGyroInvertPitch);
+		Menu_DrawOptionButton (controls_buttons-1, gyro_invert_pitch_string);
+
+		// Gyro Invert Yaw
+		Menu_DrawButton (controls_buttons++, controls_index++, "GYRO INVERT YAW",
+			"Invert Gyroscope Horizontal Axis.", Menu_Controls_ApplyGyroInvertYaw);
+		Menu_DrawOptionButton (controls_buttons-1, gyro_invert_yaw_string);
+	}
+#endif
 
 	Menu_DrawDivider(-2.5);
 	Menu_DrawButton(-2, controls_index++, "APPLY", "Save & Apply Settings.", Menu_Controls_ApplySettings);

--- a/source/menu/menu_defs.h
+++ b/source/menu/menu_defs.h
@@ -48,7 +48,7 @@ extern int				m_previous_state;
 ///////////////////////////
 ///////////////////////////
 
-#define MAX_MENU_BUTTONS 11
+#define MAX_MENU_BUTTONS 20
 
 // Curent menu state and buttons are stored here
 // when m_state is flipped, the respective menu "Set"

--- a/source/platform/ctr/in_ctr.c
+++ b/source/platform/ctr/in_ctr.c
@@ -32,6 +32,22 @@ extern float crosshair_opacity;
 
 extern cvar_t in_mlook; //Heffo - mlook cvar
 extern cvar_t in_anub_mode;
+extern cvar_t in_aimassist;
+
+// Gyroscope aiming feature added by Yassine Milal.
+// Gyroscope cvars
+extern cvar_t gyro_enable;
+extern cvar_t gyro_sensitivity;
+extern cvar_t gyro_pitch_sensitivity;
+extern cvar_t gyro_yaw_sensitivity;
+extern cvar_t gyro_invert_pitch;
+extern cvar_t gyro_invert_yaw;
+
+static qboolean gyro_was_enabled = false;
+static qboolean gyro_bias_ready = false;
+static int gyro_bias_samples = 0;
+static float gyro_bias_x = 0.0f;
+static float gyro_bias_y = 0.0f;
 
 void IN_Init (void)
 {
@@ -48,6 +64,9 @@ void IN_Init (void)
 			cppExit();
 		}
 	}
+
+	// Enable the gyroscope hardware
+	HIDUSER_EnableGyroscope();
 }
 
 void IN_Shutdown (void)
@@ -182,6 +201,93 @@ void IN_Move (usercmd_t *cmd)
 		cl.viewangles[PITCH] = 80.0f;
 	if (cl.viewangles[PITCH] < -70.0f)
 		cl.viewangles[PITCH] = -70.0f;
+
+	// ---- Gyroscope aiming ----
+	if (gyro_enable.value) {
+		angularRate gyro_data;
+		hidGyroRead(&gyro_data);
+
+		if (!gyro_was_enabled) {
+			gyro_was_enabled = true;
+			gyro_bias_ready = false;
+			gyro_bias_samples = 0;
+			gyro_bias_x = 0.0f;
+			gyro_bias_y = 0.0f;
+		}
+
+		if (!gyro_bias_ready) {
+			gyro_bias_x += gyro_data.x;
+			gyro_bias_y += gyro_data.y;
+			gyro_bias_samples++;
+
+			if (gyro_bias_samples >= 30) {
+				gyro_bias_x /= (float)gyro_bias_samples;
+				gyro_bias_y /= (float)gyro_bias_samples;
+				gyro_bias_ready = true;
+			}
+		} else {
+			float raw_yaw = gyro_data.y - gyro_bias_y;
+			float raw_pitch = gyro_data.x - gyro_bias_x;
+
+			// Filter tiny idle noise and sensor bias drift.
+			const float gyro_deadzone = 1.5f;
+			if (fabsf(raw_yaw) < gyro_deadzone)
+				raw_yaw = 0.0f;
+			if (fabsf(raw_pitch) < gyro_deadzone)
+				raw_pitch = 0.0f;
+
+			if (fabsf(raw_yaw) < (gyro_deadzone * 1.5f))
+				gyro_bias_y = (gyro_bias_y * 0.995f) + (gyro_data.y * 0.005f);
+			if (fabsf(raw_pitch) < (gyro_deadzone * 1.5f))
+				gyro_bias_x = (gyro_bias_x * 0.995f) + (gyro_data.x * 0.005f);
+
+			float gyro_sens       = gyro_sensitivity.value;
+			float gyro_yaw_sens   = gyro_yaw_sensitivity.value;
+			float gyro_pitch_sens = gyro_pitch_sensitivity.value;
+
+			// Raw gyro values are angular rate (roughly degrees/second).
+			// Scale down so the default sensitivity of 1.0 feels reasonable.
+			float gyro_scale = 0.005f;
+
+			// Landscape remap for 3DS handling:
+			// use sensor pitch for horizontal aim and roll for vertical aim.
+			float gyro_yaw   = raw_yaw   * gyro_sens * gyro_yaw_sens   * gyro_scale;
+			float gyro_pitch = raw_pitch * gyro_sens * gyro_pitch_sens * gyro_scale;
+
+			// Inversion
+			if (gyro_invert_yaw.value)
+				gyro_yaw = -gyro_yaw;
+			if (gyro_invert_pitch.value)
+				gyro_pitch = -gyro_pitch;
+
+			// Reduce gyro look speed when ADS / scoped (same as analog)
+			if (cl.stats[STAT_ZOOM] == 1) {
+				gyro_yaw   *= 0.5f;
+				gyro_pitch *= 0.5f;
+			} else if (cl.stats[STAT_ZOOM] == 2) {
+				gyro_yaw   *= 0.25f;
+				gyro_pitch *= 0.25f;
+			}
+
+			// Aim-assist slowdown
+			if ((in_aimassist.value) && (sv_player->v.facingenemy == 1)
+				&& cl.stats[STAT_CURRENTMAG] > 0) {
+				gyro_yaw   *= 0.5f;
+				gyro_pitch *= 0.5f;
+			}
+
+			cl.viewangles[YAW]   -= gyro_yaw;
+			cl.viewangles[PITCH] -= gyro_pitch;
+
+			// Re-clamp pitch
+			if (cl.viewangles[PITCH] > 80.0f)
+				cl.viewangles[PITCH] = 80.0f;
+			if (cl.viewangles[PITCH] < -70.0f)
+				cl.viewangles[PITCH] = -70.0f;
+		}
+	} else {
+		gyro_was_enabled = false;
+	}
 
 	// Ability to move with the left nub on NEW model systems
 	float move_x, move_y;


### PR DESCRIPTION
## Summary
- Add 3DS gyro controls and tuning settings in controls menu.
- Fix OG 3DS gyro mapping, inversion defaults, and idle drift behavior.
- Prevent controls menu text overlap by adding a dedicated gyro submenu.
- Add attribution comments for gyro feature work.

## 3DS-specific notes
- Gyro invert pitch/yaw defaults are enabled for better OG 3DS orientation.
- Includes gyro calibration and deadzone filtering to reduce drift at rest.

## Files changed
- source/cl_main.c
- source/menu/menu_controls.c
- source/menu/menu_defs.h
- source/platform/ctr/in_ctr.c

## Validation
- Built successfully with Makefile.ctr.
- Produced build/3ds/bin/nzportable.3dsx.