### PR TITLE
GLOBAL: Fix texture filtering setting string

### DIFF
--- a/source/menu/menu_video.c
+++ b/source/menu/menu_video.c
@@ -125,9 +125,9 @@ void Menu_Video_SetStrings (void)
     }
 
     if ((int)r_retro.value == 1) {
-        retro_string = "LINEAR";
-    } else {
         retro_string = "NEAREST";
+    } else {
+        retro_string = "LINEAR";
     }
 
     if ((int)r_dithering.value == 1) {


### PR DESCRIPTION
<!-- Note that before you open this Pull Request it should be titled to fit our standard, using prefixes specifying platform relevancy:
* `PSP`: PlayStation Portable
* `CTR`: Nintendo 3DS
* `RVL`: Nintendo Wii
* `TNS`: TI-Nspire

If commits generally are common, use the `GLOBAL` prefix.

Examples:
PSP: Add super cool texture compression for 2x rendering performance!
GLOBAL: Fix crc built-in using wrong crc algorithm
CTR/RVL: Conform to DevkitPro code standards

Ideally you should also use this standard for your commit names too. They'll likely be squashed on merge if they do not conform.
-->

### Description of Changes
---
Fixes incorrectly set string for the "Texture Filtering" option in the video menu.

### Visual Sample
---
<img width="643" height="379" alt="image" src="https://github.com/user-attachments/assets/a15affb3-2676-4fcc-b127-935acfff8356" />


### Checklist
---

- [x] I have thoroughly tested my changes to the best of my ability
- [x] I confirm I have not contributed anything that would impact Nazi Zombies: Portable's licensing and usage
- [ ] This Pull Request fixes a **critical** issue that should be reviewed and merged as soon as possible
